### PR TITLE
chore: add community extension page to website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -64,6 +64,11 @@ const config = {
             label: 'Docs',
           },
           {
+            to: 'extensions', 
+            label: 'Extensions', 
+            position: 'right'
+          },
+          {
             href: 'https://github.com/farfetch/kafkaflow',
             label: 'GitHub',
             position: 'right',

--- a/website/src/pages/extensions/index.js
+++ b/website/src/pages/extensions/index.js
@@ -1,0 +1,78 @@
+import React from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Layout from "@theme/Layout";
+
+function Extension({title, description, link})
+  {
+    return (
+      <div class="card-demo padding-top--md">
+        <div class="card">
+          <div class="card__header">
+            <h3>{title}</h3>
+          </div>
+          <div class="card__body">
+            <p>
+              {description}
+            </p>
+            <a
+              title={title}
+              href={link}
+            >
+              {link}
+            </a>
+          </div>
+        </div>
+      </div>)
+  }
+
+export default function Extensions() {
+  const ExtensionsList = [
+    {
+      title: 'KafkaFlow Retry Extensions',
+      description: (
+        <>
+          KafkaFlow Retry is a .NET framework to implement easy resilience on consumers.
+        </>
+      ),
+      link:'https://github.com/Farfetch/kafkaflow-retry-extensions'
+    },
+  ];
+
+  const { siteConfig } = useDocusaurusContext();
+
+  return (
+    <Layout
+      title={`Extensions | ${siteConfig.title}`}
+      description="KafkaFlow Extensions developed by the community"
+    >
+      <main>
+        <div class="container padding-top--md padding-bottom--lg">
+          <div class="row">
+            <div class="col">
+              <article>
+                <h1>Extensions</h1>
+                <p>Extensions developed by the community.</p>
+                <div class="alert alert--info" role="alert">
+                  If you are an extension author and want to have your extension
+                  listed, please let us know{" "}
+                  <a href="https://github.com/Farfetch/kafkaflow/issues">
+                    here
+                  </a>
+                  .
+                </div>
+
+                <div class="row">
+                  <div class="col">
+                    {ExtensionsList.map((props, idx) => (
+                      <Extension key={idx} {...props} />
+                    ))}
+                  </div>
+                </div>
+              </article>
+            </div>
+          </div>
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
# Description

Create a page to list community extensions to KafkaFlow.

<img width="2416" alt="image" src="https://user-images.githubusercontent.com/1719764/202212638-0ad116f4-e949-49e1-93bf-fe6d651fd375.png">


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
