### PR TITLE
chore: trigger docs deploy once changes are in master

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,8 +1,12 @@
 name: Deploy to GitHub Pages
 
 on:
-  release:
-    types: [ published ]
+  push:
+    branches:
+      - master
+      - release-*
+    paths:
+      - "website/**"
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KafkaFlow
 
-![Build Master](https://github.com/Farfetch/kafkaflow/workflows/Build%20Master/badge.svg?branch=master) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/49878b337fde46839c5f08051c2ba098)](https://app.codacy.com/gh/Farfetch/kafkaflow?utm_source=github.com&utm_medium=referral&utm_content=Farfetch/kafkaflow&utm_campaign=Badge_Grade_Dashboard) [![Slack](https://img.shields.io/badge/slack-@kafkaflow-green.svg?logo=slack)](https://join.slack.com/t/kafkaflow/shared_invite/zt-puihrtcl-NnnylPZloAiVlQfsw~RD6Q)
+![Build Master](https://github.com/Farfetch/kafkaflow/workflows/Build/badge.svg?branch=master) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/49878b337fde46839c5f08051c2ba098)](https://app.codacy.com/gh/Farfetch/kafkaflow?utm_source=github.com&utm_medium=referral&utm_content=Farfetch/kafkaflow&utm_campaign=Badge_Grade_Dashboard) [![Slack](https://img.shields.io/badge/slack-@kafkaflow-green.svg?logo=slack)](https://join.slack.com/t/kafkaflow/shared_invite/zt-puihrtcl-NnnylPZloAiVlQfsw~RD6Q)
 
 ## Introduction
 


### PR DESCRIPTION
# Description

- Trigger docs deploy once changes are in master instead of only on release since docs evolve at a different pace.
- Fix: broken build status link on the home page.

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
