### PR TITLE
chore: improve admin and telemetry messages to not store offsets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
 
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
 
       - run: dotnet tool install --global gsferreira.XmlDocMarkdown.Docusaurus --version 0.0.1-beta1 # using this version while the Pull Request isn't accepted here: https://github.com/ejball/XmlDocMarkdown/pull/126
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
 
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/test-deploy-website.yml
+++ b/.github/workflows/test-deploy-website.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
 
       - run: dotnet tool install --global gsferreira.XmlDocMarkdown.Docusaurus --version 0.0.1-beta1 # using this version while the Pull Request isn't accepted here: https://github.com/ejball/XmlDocMarkdown/pull/126
         shell: bash

--- a/samples/KafkaFlow.Sample.BatchOperations/KafkaFlow.Sample.BatchOperations.csproj
+++ b/samples/KafkaFlow.Sample.BatchOperations/KafkaFlow.Sample.BatchOperations.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <InvariantGlobalization>true</InvariantGlobalization>

--- a/samples/KafkaFlow.Sample.BatchOperations/KafkaFlow.Sample.BatchOperations.csproj
+++ b/samples/KafkaFlow.Sample.BatchOperations/KafkaFlow.Sample.BatchOperations.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/samples/KafkaFlow.Sample.Dashboard/KafkaFlow.Sample.Dashboard.csproj
+++ b/samples/KafkaFlow.Sample.Dashboard/KafkaFlow.Sample.Dashboard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>

--- a/samples/KafkaFlow.Sample.Dashboard/KafkaFlow.Sample.Dashboard.csproj
+++ b/samples/KafkaFlow.Sample.Dashboard/KafkaFlow.Sample.Dashboard.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\src\KafkaFlow.Admin.Dashboard\KafkaFlow.Admin.Dashboard.csproj" />
     <ProjectReference Include="..\..\src\KafkaFlow.Admin.WebApi\KafkaFlow.Admin.WebApi.csproj" />
     <ProjectReference Include="..\..\src\KafkaFlow.Admin\KafkaFlow.Admin.csproj" />
+    <ProjectReference Include="..\..\src\KafkaFlow.Extensions.Hosting\KafkaFlow.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\..\src\KafkaFlow.LogHandler.Console\KafkaFlow.LogHandler.Console.csproj" />
     <ProjectReference Include="..\..\src\KafkaFlow.Microsoft.DependencyInjection\KafkaFlow.Microsoft.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\src\KafkaFlow\KafkaFlow.csproj" />

--- a/samples/KafkaFlow.Sample.Dashboard/Program.cs
+++ b/samples/KafkaFlow.Sample.Dashboard/Program.cs
@@ -1,5 +1,7 @@
 namespace KafkaFlow.Sample.Dashboard
 {
+    using System;
+    using System.Net;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Hosting;
 
@@ -11,6 +13,12 @@ namespace KafkaFlow.Sample.Dashboard
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(
+                    webBuilder =>
+                    {
+                        webBuilder.ConfigureKestrel(x => x.Listen(IPAddress.Any, new Random().Next(5000, 5020)));
+                        webBuilder.UseStartup<Startup>();
+                    });
     }
 }

--- a/samples/KafkaFlow.Sample.Dashboard/Program.cs
+++ b/samples/KafkaFlow.Sample.Dashboard/Program.cs
@@ -1,7 +1,5 @@
 namespace KafkaFlow.Sample.Dashboard
 {
-    using System;
-    using System.Net;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Hosting;
 
@@ -13,12 +11,6 @@ namespace KafkaFlow.Sample.Dashboard
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(
-                    webBuilder =>
-                    {
-                        webBuilder.ConfigureKestrel(x => x.Listen(IPAddress.Any, new Random().Next(5000, 5020)));
-                        webBuilder.UseStartup<Startup>();
-                    });
+            Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
     }
 }

--- a/samples/KafkaFlow.Sample.Dashboard/Startup.cs
+++ b/samples/KafkaFlow.Sample.Dashboard/Startup.cs
@@ -11,7 +11,7 @@ namespace KafkaFlow.Sample.Dashboard
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddKafka(
+            services.AddKafkaFlowHostedService(
                 kafka => kafka
                     .UseConsoleLog()
                     .AddCluster(
@@ -41,10 +41,6 @@ namespace KafkaFlow.Sample.Dashboard
                 .UseRouting()
                 .UseEndpoints(endpoints => { endpoints.MapControllers(); })
                 .UseKafkaFlowDashboard();
-
-            var kafkaBus = app.ApplicationServices.CreateKafkaBus();
-
-            lifetime.ApplicationStarted.Register(() => kafkaBus.StartAsync(lifetime.ApplicationStopped));
         }
     }
 }

--- a/samples/KafkaFlow.Sample.FlowControl/KafkaFlow.Sample.FlowControl.csproj
+++ b/samples/KafkaFlow.Sample.FlowControl/KafkaFlow.Sample.FlowControl.csproj
@@ -6,6 +6,7 @@
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <LangVersion>9</LangVersion>
+        <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/samples/KafkaFlow.Sample.FlowControl/KafkaFlow.Sample.FlowControl.csproj
+++ b/samples/KafkaFlow.Sample.FlowControl/KafkaFlow.Sample.FlowControl.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <LangVersion>9</LangVersion>

--- a/samples/KafkaFlow.Sample.SchemaRegistry/KafkaFlow.Sample.SchemaRegistry.csproj
+++ b/samples/KafkaFlow.Sample.SchemaRegistry/KafkaFlow.Sample.SchemaRegistry.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AssemblyName>KafkaFlow.Sample.SchemaRegistry</AssemblyName>

--- a/samples/KafkaFlow.Sample.SchemaRegistry/KafkaFlow.Sample.SchemaRegistry.csproj
+++ b/samples/KafkaFlow.Sample.SchemaRegistry/KafkaFlow.Sample.SchemaRegistry.csproj
@@ -7,6 +7,7 @@
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AssemblyName>KafkaFlow.Sample.SchemaRegistry</AssemblyName>
         <RootNamespace>KafkaFlow.Sample.SchemaRegistry</RootNamespace>
+        <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/samples/KafkaFlow.Sample.WebApi/KafkaFlow.Sample.WebApi.csproj
+++ b/samples/KafkaFlow.Sample.WebApi/KafkaFlow.Sample.WebApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>

--- a/samples/KafkaFlow.Sample.WebApi/KafkaFlow.Sample.WebApi.csproj
+++ b/samples/KafkaFlow.Sample.WebApi/KafkaFlow.Sample.WebApi.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <IsPackable>false</IsPackable>
+        <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/samples/KafkaFlow.Sample/KafkaFlow.Sample.csproj
+++ b/samples/KafkaFlow.Sample/KafkaFlow.Sample.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <InvariantGlobalization>true</InvariantGlobalization>

--- a/samples/KafkaFlow.Sample/KafkaFlow.Sample.csproj
+++ b/samples/KafkaFlow.Sample/KafkaFlow.Sample.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/samples/KafkaFlow.Sample/Program.cs
+++ b/samples/KafkaFlow.Sample/Program.cs
@@ -72,7 +72,7 @@
                     }
                 }
 
-                if (input!.Equals("exit", StringComparison.InvariantCultureIgnoreCase))
+                if (input!.Equals("exit", StringComparison.OrdinalIgnoreCase))
                 {
                     await bus.StopAsync();
                     break;

--- a/src/KafkaFlow.Abstractions/Configuration/IConsumerConfigurationBuilder.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/IConsumerConfigurationBuilder.cs
@@ -14,21 +14,29 @@ namespace KafkaFlow.Configuration
         IDependencyConfigurator DependencyConfigurator { get; }
 
         /// <summary>
-        /// Sets the topic that will be used to read the messages
+        /// Sets the topic that will be used to read the messages, the partitions will be automatically assigned
         /// </summary>
         /// <param name="topicName">Topic name</param>
         /// <returns></returns>
         IConsumerConfigurationBuilder Topic(string topicName);
 
         /// <summary>
-        /// Sets the topics that will be used to read the messages
+        /// Explicitly defines the topic and partitions that will be used to read the messages
+        /// </summary>
+        /// <param name="topicName">Topic name</param>
+        /// <param name="partitions">The partitions IDs</param>
+        /// <returns></returns>
+        IConsumerConfigurationBuilder ManualAssignPartitions(string topicName, IEnumerable<int> partitions);
+
+        /// <summary>
+        /// Sets the topics that will be used to read the messages, the partitions will be automatically assigned
         /// </summary>
         /// <param name="topicNames">Topic names</param>
         /// <returns></returns>
         IConsumerConfigurationBuilder Topics(IEnumerable<string> topicNames);
 
         /// <summary>
-        /// Sets the topics that will be used to read the messages
+        /// Sets the topics that will be used to read the messages, the partitions will be automatically assigned
         /// </summary>
         /// <param name="topicNames">Topic names</param>
         /// <returns></returns>
@@ -134,6 +142,12 @@ namespace KafkaFlow.Configuration
         /// </summary>
         /// <returns></returns>
         IConsumerConfigurationBuilder WithManualStoreOffsets();
+
+        /// <summary>
+        /// No offsets will be stored on Kafka
+        /// </summary>
+        /// <returns></returns>
+        IConsumerConfigurationBuilder WithoutStoringOffsets();
 
         /// <summary>
         /// Configures the consumer initial state.The default is <see cref="ConsumerInitialState.Running"/>

--- a/src/KafkaFlow.Abstractions/Configuration/TopicPartitions.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/TopicPartitions.cs
@@ -1,0 +1,17 @@
+namespace KafkaFlow.Configuration
+{
+    using System.Collections.Generic;
+
+    public class TopicPartitions
+    {
+        public TopicPartitions(string name, IEnumerable<int> partitions)
+        {
+            this.Name = name;
+            this.Partitions = partitions;
+        }
+
+        public string Name { get; }
+
+        public IEnumerable<int> Partitions { get; }
+    }
+}

--- a/src/KafkaFlow.Admin/AdminProducer.cs
+++ b/src/KafkaFlow.Admin/AdminProducer.cs
@@ -7,10 +7,15 @@ namespace KafkaFlow.Admin
     internal class AdminProducer : IAdminProducer
     {
         private readonly IMessageProducer<AdminProducer> producer;
+        private readonly int topicPartition;
 
-        public AdminProducer(IMessageProducer<AdminProducer> producer) => this.producer = producer;
+        public AdminProducer(IMessageProducer<AdminProducer> producer, int topicPartition)
+        {
+            this.producer = producer;
+            this.topicPartition = topicPartition;
+        }
 
         public Task ProduceAsync(IAdminMessage message) =>
-            this.producer.ProduceAsync(Guid.NewGuid().ToString(), message);
+            this.producer.ProduceAsync(Guid.NewGuid().ToString(), message, partition: this.topicPartition);
     }
 }

--- a/src/KafkaFlow.Admin/ITelemetryScheduler.cs
+++ b/src/KafkaFlow.Admin/ITelemetryScheduler.cs
@@ -2,7 +2,7 @@ namespace KafkaFlow.Admin
 {
     internal interface ITelemetryScheduler
     {
-        void Start(string telemetryId, string topicName);
+        void Start(string telemetryId, string topicName, int topicPartition);
 
         void Stop(string telemetryId);
     }

--- a/src/KafkaFlow.BatchConsume/BatchConsumeMiddleware.cs
+++ b/src/KafkaFlow.BatchConsume/BatchConsumeMiddleware.cs
@@ -5,7 +5,7 @@
     using System.Threading;
     using System.Threading.Tasks;
 
-    internal class BatchConsumeMiddleware : IMessageMiddleware
+    internal class BatchConsumeMiddleware : IMessageMiddleware, IDisposable
     {
         private readonly int batchSize;
         private readonly TimeSpan batchTimeout;
@@ -45,6 +45,11 @@
                 this.cancelScheduleTokenSource.Cancel();
                 await (await this.dispatchTask.ConfigureAwait(false)).ConfigureAwait(false);
             }
+        }
+
+        public void Dispose()
+        {
+            this.cancelScheduleTokenSource?.Dispose();
         }
 
         private async Task Dispatch(IMessageContext context, MiddlewareDelegate next)

--- a/src/KafkaFlow.IntegrationTests/KafkaFlow.IntegrationTests.csproj
+++ b/src/KafkaFlow.IntegrationTests/KafkaFlow.IntegrationTests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
+        <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/KafkaFlow.UnitTests/Consumer/ConsumerManagerTests.cs
+++ b/src/KafkaFlow.UnitTests/Consumer/ConsumerManagerTests.cs
@@ -37,11 +37,11 @@ namespace KafkaFlow.UnitTests.Consumer
             this.dependencyResolver = new Mock<IDependencyResolver>();
 
             this.consumerMock
-                .Setup(x => x.OnPartitionsAssigned(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartition>>>()))
+                .Setup(x => x.OnPartitionsAssigned(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>>>()))
                 .Callback((Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> value) => this.onPartitionAssignedHandler = value);
 
             this.consumerMock
-                .Setup(x => x.OnPartitionsRevoked(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartitionOffset>>>()))
+                .Setup(x => x.OnPartitionsRevoked(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>>>()))
                 .Callback((Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> value) => this.onPartitionRevokedHandler = value);
 
             this.target = new ConsumerManager(

--- a/src/KafkaFlow.UnitTests/Consumer/ConsumerManagerTests.cs
+++ b/src/KafkaFlow.UnitTests/Consumer/ConsumerManagerTests.cs
@@ -37,11 +37,11 @@ namespace KafkaFlow.UnitTests.Consumer
             this.dependencyResolver = new Mock<IDependencyResolver>();
 
             this.consumerMock
-                .Setup(x => x.OnPartitionsAssigned(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>>>()))
+                .Setup(x => x.OnPartitionsAssigned(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartition>>>()))
                 .Callback((Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> value) => this.onPartitionAssignedHandler = value);
 
             this.consumerMock
-                .Setup(x => x.OnPartitionsRevoked(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>>>()))
+                .Setup(x => x.OnPartitionsRevoked(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartitionOffset>>>()))
                 .Callback((Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> value) => this.onPartitionRevokedHandler = value);
 
             this.target = new ConsumerManager(

--- a/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
+++ b/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
@@ -2,7 +2,8 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
+        <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/KafkaFlow.UnitTests/Serializers/NewtonsoftJsonSerializerTests.cs
+++ b/src/KafkaFlow.UnitTests/Serializers/NewtonsoftJsonSerializerTests.cs
@@ -14,10 +14,10 @@ namespace KafkaFlow.UnitTests.Serializers
     [TestClass]
     public class NewtonsoftJsonSerializerTests
     {
-        private Mock<ISerializerContext> contextMock = new ();
-        private NewtonsoftJsonSerializer serializer = new ();
+        private readonly Mock<ISerializerContext> contextMock = new ();
+        private readonly NewtonsoftJsonSerializer serializer = new ();
 
-        private Fixture fixture = new();
+        private readonly Fixture fixture = new();
 
         [TestMethod]
         public async Task SerializeAsync_ValidPayload_JsonByteArrayGenerated()

--- a/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
@@ -26,8 +26,8 @@ namespace KafkaFlow.Configuration
             ConsumerInitialState initialState,
             TimeSpan autoCommitInterval,
             IReadOnlyList<Action<string>> statisticsHandlers,
-            IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartition>>> partitionsAssignedHandlers,
-            IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartitionOffset>>> partitionsRevokedHandlers,
+            IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> partitionsAssignedHandlers,
+            IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> partitionsRevokedHandlers,
             IReadOnlyList<(Action<IDependencyResolver, IEnumerable<TopicPartitionOffset>> handler, TimeSpan interval)>
                 pendingOffsetsHandlers,
             ConsumerCustomFactory customFactory)
@@ -110,9 +110,9 @@ namespace KafkaFlow.Configuration
 
         public IReadOnlyList<Action<string>> StatisticsHandlers { get; }
 
-        public IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartition>>> PartitionsAssignedHandlers { get; }
+        public IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> PartitionsAssignedHandlers { get; }
 
-        public IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
+        public IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
 
         public IReadOnlyList<(Action<IDependencyResolver, IEnumerable<TopicPartitionOffset>> handler, TimeSpan interval)>
             PendingOffsetsHandlers { get; }

--- a/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
@@ -12,6 +12,7 @@ namespace KafkaFlow.Configuration
         public ConsumerConfiguration(
             ConsumerConfig consumerConfig,
             IReadOnlyList<string> topics,
+            IReadOnlyList<TopicPartitions> manualAssignPartitions,
             string consumerName,
             ClusterConfiguration clusterConfiguration,
             bool managementDisabled,
@@ -21,11 +22,12 @@ namespace KafkaFlow.Configuration
             Factory<IDistributionStrategy> distributionStrategyFactory,
             IReadOnlyList<MiddlewareConfiguration> middlewaresConfigurations,
             bool autoStoreOffsets,
+            bool noStoreOffsets,
             ConsumerInitialState initialState,
             TimeSpan autoCommitInterval,
             IReadOnlyList<Action<string>> statisticsHandlers,
-            IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> partitionsAssignedHandlers,
-            IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> partitionsRevokedHandlers,
+            IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartition>>> partitionsAssignedHandlers,
+            IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartitionOffset>>> partitionsRevokedHandlers,
             IReadOnlyList<(Action<IDependencyResolver, IEnumerable<TopicPartitionOffset>> handler, TimeSpan interval)>
                 pendingOffsetsHandlers,
             ConsumerCustomFactory customFactory)
@@ -42,9 +44,11 @@ namespace KafkaFlow.Configuration
             this.MiddlewaresConfigurations =
                 middlewaresConfigurations ?? throw new ArgumentNullException(nameof(middlewaresConfigurations));
             this.AutoStoreOffsets = autoStoreOffsets;
+            this.NoStoreOffsets = noStoreOffsets;
             this.InitialState = initialState;
             this.AutoCommitInterval = autoCommitInterval;
             this.Topics = topics ?? throw new ArgumentNullException(nameof(topics));
+            this.ManualAssignPartitions = manualAssignPartitions ?? throw new ArgumentNullException(nameof(manualAssignPartitions));
             this.ConsumerName = consumerName ?? Guid.NewGuid().ToString();
             this.ClusterConfiguration = clusterConfiguration;
             this.ManagementDisabled = managementDisabled;
@@ -69,6 +73,8 @@ namespace KafkaFlow.Configuration
         public IReadOnlyList<MiddlewareConfiguration> MiddlewaresConfigurations { get; }
 
         public IReadOnlyList<string> Topics { get; }
+
+        public IReadOnlyList<TopicPartitions> ManualAssignPartitions { get; }
 
         public string ConsumerName { get; }
 
@@ -96,15 +102,17 @@ namespace KafkaFlow.Configuration
 
         public bool AutoStoreOffsets { get; }
 
+        public bool NoStoreOffsets { get; }
+
         public ConsumerInitialState InitialState { get; }
 
         public TimeSpan AutoCommitInterval { get; }
 
         public IReadOnlyList<Action<string>> StatisticsHandlers { get; }
 
-        public IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> PartitionsAssignedHandlers { get; }
+        public IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartition>>> PartitionsAssignedHandlers { get; }
 
-        public IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
+        public IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
 
         public IReadOnlyList<(Action<IDependencyResolver, IEnumerable<TopicPartitionOffset>> handler, TimeSpan interval)>
             PendingOffsetsHandlers { get; }

--- a/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
@@ -16,8 +16,8 @@ namespace KafkaFlow.Configuration
         private readonly List<(Action<IDependencyResolver, IEnumerable<TopicPartitionOffset>>, TimeSpan interval)>
             pendingOffsetsStatisticsHandlers = new();
 
-        private readonly List<Action<IDependencyResolver, IReadOnlyList<TopicPartition>>> partitionAssignedHandlers = new();
-        private readonly List<Action<IDependencyResolver, IReadOnlyList<TopicPartitionOffset>>> partitionRevokedHandlers = new();
+        private readonly List<Action<IDependencyResolver, List<TopicPartition>>> partitionAssignedHandlers = new();
+        private readonly List<Action<IDependencyResolver, List<TopicPartitionOffset>>> partitionRevokedHandlers = new();
         private readonly ConsumerMiddlewareConfigurationBuilder middlewareConfigurationBuilder;
 
         private ConsumerConfig consumerConfig;
@@ -190,14 +190,14 @@ namespace KafkaFlow.Configuration
         }
 
         public IConsumerConfigurationBuilder WithPartitionsAssignedHandler(
-            Action<IDependencyResolver, IReadOnlyList<TopicPartition>> partitionsAssignedHandler)
+            Action<IDependencyResolver, List<TopicPartition>> partitionsAssignedHandler)
         {
             this.partitionAssignedHandlers.Add(partitionsAssignedHandler);
             return this;
         }
 
         public IConsumerConfigurationBuilder WithPartitionsRevokedHandler(
-            Action<IDependencyResolver, IReadOnlyList<TopicPartitionOffset>> partitionsRevokedHandler)
+            Action<IDependencyResolver, List<TopicPartitionOffset>> partitionsRevokedHandler)
         {
             this.partitionRevokedHandlers.Add(partitionsRevokedHandler);
             return this;

--- a/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
@@ -88,12 +88,12 @@ namespace KafkaFlow.Configuration
         /// <summary>
         /// Gets the handlers that will be called when the partitions are assigned
         /// </summary>
-        IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartition>>> PartitionsAssignedHandlers { get; }
+        IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> PartitionsAssignedHandlers { get; }
 
         /// <summary>
         /// Gets the handlers that will be called when the partitions are revoked
         /// </summary>
-        IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
+        IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
 
         /// <summary>
         /// Gets the handlers that will be called when there are pending offsets

--- a/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
@@ -25,6 +25,11 @@ namespace KafkaFlow.Configuration
         IReadOnlyList<string> Topics { get; }
 
         /// <summary>
+        /// Gets the topic partitions to manually assign
+        /// </summary>
+        IReadOnlyList<TopicPartitions> ManualAssignPartitions { get; }
+
+        /// <summary>
         /// Gets the consumer name
         /// </summary>
         string ConsumerName { get; }
@@ -66,6 +71,11 @@ namespace KafkaFlow.Configuration
         bool AutoStoreOffsets { get; }
 
         /// <summary>
+        /// Gets a value indicating that no offsets will be stored on Kafka
+        /// </summary>
+        bool NoStoreOffsets { get; }
+
+        /// <summary>
         /// Gets the interval between commits
         /// </summary>
         TimeSpan AutoCommitInterval { get; }
@@ -78,12 +88,12 @@ namespace KafkaFlow.Configuration
         /// <summary>
         /// Gets the handlers that will be called when the partitions are assigned
         /// </summary>
-        IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> PartitionsAssignedHandlers { get; }
+        IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartition>>> PartitionsAssignedHandlers { get; }
 
         /// <summary>
         /// Gets the handlers that will be called when the partitions are revoked
         /// </summary>
-        IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
+        IReadOnlyList<Action<IDependencyResolver, IReadOnlyList<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
 
         /// <summary>
         /// Gets the handlers that will be called when there are pending offsets

--- a/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
@@ -90,7 +90,7 @@ namespace KafkaFlow.Configuration
             this.producerConfig.StatisticsIntervalMs = this.statisticsInterval;
             this.producerConfig.LingerMs = this.lingerMs;
 
-            this.producerConfig.ReadSecurityInformation(clusterConfiguration);
+            this.producerConfig.ReadSecurityInformationFrom(clusterConfiguration);
 
             var configuration = new ProducerConfiguration(
                 clusterConfiguration,

--- a/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
@@ -16,7 +16,7 @@ namespace KafkaFlow.Configuration
         private Acks? acks;
         private int statisticsInterval;
         private double? lingerMs;
-        private ProducerCustomFactory customFactory = (producer, resolver) => producer;
+        private ProducerCustomFactory customFactory = (producer, _) => producer;
 
         public ProducerConfigurationBuilder(IDependencyConfigurator dependencyConfigurator, string name)
         {

--- a/src/KafkaFlow/Consumers/Consumer.cs
+++ b/src/KafkaFlow/Consumers/Consumer.cs
@@ -13,10 +13,10 @@ namespace KafkaFlow.Consumers
         private readonly IDependencyResolver dependencyResolver;
         private readonly ILogHandler logHandler;
 
-        private readonly List<Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartition>>>
+        private readonly List<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>>>
             partitionsAssignedHandlers = new();
 
-        private readonly List<Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartitionOffset>>>
+        private readonly List<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>>>
             partitionsRevokedHandlers = new();
 
         private readonly List<Action<IConsumer<byte[], byte[]>, Error>> errorsHandlers = new();
@@ -88,11 +88,11 @@ namespace KafkaFlow.Consumers
             }
         }
 
-        public void OnPartitionsAssigned(Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartition>> handler) =>
+        public void OnPartitionsAssigned(Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> handler) =>
             this.partitionsAssignedHandlers.Add(handler);
 
         public void OnPartitionsRevoked(
-            Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartitionOffset>> handler) =>
+            Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> handler) =>
             this.partitionsRevokedHandlers.Add(handler);
 
         public void OnError(Action<IConsumer<byte[], byte[]>, Error> handler) =>
@@ -254,7 +254,7 @@ namespace KafkaFlow.Consumers
             this.FirePartitionsAssignedHandlers(this.consumer, partitions);
         }
 
-        private void FirePartitionsAssignedHandlers(IConsumer<byte[], byte[]> consumer, IReadOnlyList<TopicPartition> partitions)
+        private void FirePartitionsAssignedHandlers(IConsumer<byte[], byte[]> consumer, List<TopicPartition> partitions)
         {
             this.Assignment = partitions;
             this.Subscription = consumer.Subscription;

--- a/src/KafkaFlow/Consumers/IConsumer.cs
+++ b/src/KafkaFlow/Consumers/IConsumer.cs
@@ -49,13 +49,13 @@ namespace KafkaFlow.Consumers
         /// Register a handler to be executed when the partitions are assigned
         /// </summary>
         /// <param name="handler">The handler that will be executed</param>
-        void OnPartitionsAssigned(Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> handler);
+        void OnPartitionsAssigned(Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartition>> handler);
 
         /// <summary>
         /// Register a handler to be executed when the partitions are revoked
         /// </summary>
         /// <param name="handler">The handler that will be executed</param>
-        void OnPartitionsRevoked(Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> handler);
+        void OnPartitionsRevoked(Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartitionOffset>> handler);
 
         /// <summary>
         /// Register a handler to be executed when an error occurs

--- a/src/KafkaFlow/Consumers/IConsumer.cs
+++ b/src/KafkaFlow/Consumers/IConsumer.cs
@@ -49,13 +49,13 @@ namespace KafkaFlow.Consumers
         /// Register a handler to be executed when the partitions are assigned
         /// </summary>
         /// <param name="handler">The handler that will be executed</param>
-        void OnPartitionsAssigned(Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartition>> handler);
+        void OnPartitionsAssigned(Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> handler);
 
         /// <summary>
         /// Register a handler to be executed when the partitions are revoked
         /// </summary>
         /// <param name="handler">The handler that will be executed</param>
-        void OnPartitionsRevoked(Action<IDependencyResolver, IConsumer<byte[], byte[]>, IReadOnlyList<TopicPartitionOffset>> handler);
+        void OnPartitionsRevoked(Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> handler);
 
         /// <summary>
         /// Register a handler to be executed when an error occurs

--- a/src/KafkaFlow/Consumers/NullOffsetCommitter.cs
+++ b/src/KafkaFlow/Consumers/NullOffsetCommitter.cs
@@ -1,0 +1,17 @@
+namespace KafkaFlow.Consumers
+{
+    using Confluent.Kafka;
+
+    internal class NullOffsetCommitter : IOffsetCommitter
+    {
+        public void Dispose()
+        {
+            // Do nothing
+        }
+
+        public void MarkAsProcessed(TopicPartitionOffset tpo)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/src/KafkaFlow/Consumers/WorkerPoolFeeder.cs
+++ b/src/KafkaFlow/Consumers/WorkerPoolFeeder.cs
@@ -64,15 +64,15 @@ namespace KafkaFlow.Consumers
                 CancellationToken.None);
         }
 
-        public Task StopAsync()
+        public async Task StopAsync()
         {
-            if (this.stopTokenSource != null && !this.stopTokenSource.IsCancellationRequested)
+            if (this.stopTokenSource is { IsCancellationRequested: false })
             {
                 this.stopTokenSource.Cancel();
                 this.stopTokenSource.Dispose();
             }
 
-            return this.feederTask ?? Task.CompletedTask;
+            await (this.feederTask ?? Task.CompletedTask);
         }
     }
 }

--- a/src/KafkaFlow/Extensions/ConfigurationExtensions.cs
+++ b/src/KafkaFlow/Extensions/ConfigurationExtensions.cs
@@ -35,7 +35,7 @@ namespace KafkaFlow
                 _ => throw new ArgumentOutOfRangeException()
             };
 
-        public static void ReadSecurityInformation(this ClientConfig config, ClusterConfiguration cluster)
+        public static void ReadSecurityInformationFrom(this ClientConfig config, ClusterConfiguration cluster)
         {
             var securityInformation = cluster.GetSecurityInformation();
 

--- a/src/KafkaFlow/Producers/IMessageProducer.cs
+++ b/src/KafkaFlow/Producers/IMessageProducer.cs
@@ -29,12 +29,14 @@ namespace KafkaFlow
         /// <param name="messageKey">The message key</param>
         /// <param name="messageValue">The message value</param>
         /// <param name="headers">The message headers</param>
+        /// <param name="partition">The partition where the message will be produced, if no partition is provided it will be calculated using the message key</param>
         /// <returns></returns>
         Task<DeliveryResult<byte[], byte[]>> ProduceAsync(
             string topic,
             object messageKey,
             object messageValue,
-            IMessageHeaders headers = null);
+            IMessageHeaders headers = null,
+            int? partition = null);
 
         /// <summary>
         /// Produces a new message in the configured default topic
@@ -42,11 +44,13 @@ namespace KafkaFlow
         /// <param name="messageKey">The message key</param>
         /// <param name="messageValue">The message value</param>
         /// <param name="headers">The message headers</param>
+        /// <param name="partition">The partition where the message will be produced, if no partition is provided it will be calculated using the message key</param>
         /// <returns></returns>
         Task<DeliveryResult<byte[], byte[]>> ProduceAsync(
             object messageKey,
             object messageValue,
-            IMessageHeaders headers = null);
+            IMessageHeaders headers = null,
+            int? partition = null);
 
         /// <summary>
         /// Produces a new message
@@ -57,12 +61,14 @@ namespace KafkaFlow
         /// <param name="messageValue">The message value</param>
         /// <param name="headers">The message headers</param>
         /// <param name="deliveryHandler">A handler with the operation result</param>
+        /// <param name="partition">The partition where the message will be produced, if no partition is provided it will be calculated using the message key</param>
         void Produce(
             string topic,
             object messageKey,
             object messageValue,
             IMessageHeaders headers = null,
-            Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null);
+            Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null,
+            int? partition = null);
 
         /// <summary>
         /// Produces a new message in the configured default topic
@@ -72,10 +78,12 @@ namespace KafkaFlow
         /// <param name="messageValue">The message value</param>
         /// <param name="headers">The message headers</param>
         /// <param name="deliveryHandler">A handler with the operation result</param>
+        /// <param name="partition">The partition where the message will be produced, if no partition is provided it will be calculated using the message key</param>
         void Produce(
             object messageKey,
             object messageValue,
             IMessageHeaders headers = null,
-            Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null);
+            Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null,
+            int? partition = null);
     }
 }

--- a/src/KafkaFlow/Producers/MessageProducer.cs
+++ b/src/KafkaFlow/Producers/MessageProducer.cs
@@ -124,7 +124,7 @@ namespace KafkaFlow.Producers
                         if (task.IsFaulted)
                         {
                             deliveryHandler?.Invoke(
-                                new DeliveryReport<byte[], byte[]>()
+                                new DeliveryReport<byte[], byte[]>
                                 {
                                     Error = new Error(ErrorCode.Local_Fail, task.Exception?.Message),
                                     Status = PersistenceStatus.NotPersisted,

--- a/src/KafkaFlow/Producers/MessageProducerWrapper.cs
+++ b/src/KafkaFlow/Producers/MessageProducerWrapper.cs
@@ -19,52 +19,60 @@ namespace KafkaFlow.Producers
             string topic,
             object messageKey,
             object message,
-            IMessageHeaders headers = null)
+            IMessageHeaders headers = null,
+            int? partition = null)
         {
             return this.producer.ProduceAsync(
                 topic,
                 messageKey,
                 message,
-                headers);
+                headers,
+                partition);
         }
 
         public Task<DeliveryResult<byte[], byte[]>> ProduceAsync(
-            object partitionKey,
+            object messageKey,
             object message,
-            IMessageHeaders headers = null)
+            IMessageHeaders headers = null,
+            int? partition = null)
         {
             return this.producer.ProduceAsync(
-                partitionKey,
+                messageKey,
                 message,
-                headers);
+                headers,
+                partition);
         }
 
         public void Produce(
             string topic,
-            object partitionKey,
+            object messageKey,
             object message,
             IMessageHeaders headers = null,
-            Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null)
+            Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null,
+            int? partition = null)
         {
             this.producer.Produce(
                 topic,
-                partitionKey,
+                messageKey,
                 message,
                 headers,
-                deliveryHandler);
+                deliveryHandler,
+                partition);
         }
 
         public void Produce(
-            object partitionKey,
+            object messageKey,
             object message,
             IMessageHeaders headers = null,
-            Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null)
+            Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null,
+            int? partition = null)
         {
             this.producer.Produce(
-                partitionKey,
+                messageKey,
                 message,
                 headers,
-                deliveryHandler);
+                deliveryHandler,
+                partition);
         }
     }
 }

--- a/website/docs/guides/consumers/add-consumers.md
+++ b/website/docs/guides/consumers/add-consumers.md
@@ -31,9 +31,52 @@ services.AddKafka(kafka => kafka
 
 On a Consumer, you can configure the Middlewares that will be invoked. You can find more information on how to configure Middlewares [here](../middlewares).
 
+## Automatic Partitions Assignment
+
+Using the `Topic()` or `Topics()` methods, the consumer will trigger the automatic partition assignment that will distribute the topic partitions across the application instances.
+
+
+```csharp
+using KafkaFlow;
+using KafkaFlow.Serializer;
+using Microsoft.Extensions.DependencyInjection;
+using KafkaFlow.TypedHandler;
+
+services.AddKafka(kafka => kafka
+    .AddCluster(cluster => cluster
+        .WithBrokers(new[] { "localhost:9092" })
+        .AddConsumer(consumer => consumer
+            .Topic("topic-name")
+            .WithGroupId("sample-group")
+            ...
+        )
+    )
+);
+```
+
+## Manual Partitions Assignment
+
+The client application can specify the topic partitions manually using the `ManualAssignPartitions()` method instead of using the `Topic()` or `Topics()` methods.
+
+
+```csharp
+using KafkaFlow;
+using KafkaFlow.Serializer;
+using Microsoft.Extensions.DependencyInjection;
+using KafkaFlow.TypedHandler;
+
+services.AddKafka(kafka => kafka
+    .AddCluster(cluster => cluster
+        .WithBrokers(new[] { "localhost:9092" })
+        .AddConsumer(consumer => consumer
+            .ManualAssignPartitions("topic-name", new[] { 1, 2, 3 })
+            ...
+        )
+    )
+);
+```
 
 ## Offset Strategy
-
 
 You can configure the Offset Strategy for a consumer group in case the Consumer Group has no offset stored in Kafka. 
 There are two options:
@@ -76,6 +119,30 @@ services.AddKafka(kafka => kafka
             .Topic("topic-name")
             .WithGroupId("sample-group")
             .WithManualStoreOffsets()
+            ...
+        )
+    )
+);
+```
+
+## Disable Store Offsets
+
+In a scenario where storing offsets it's not needed,  you can disable it by calling the `WithoutStoringOffsets()` method in the consumer setup.
+
+
+```csharp
+using KafkaFlow;
+using KafkaFlow.Serializer;
+using Microsoft.Extensions.DependencyInjection;
+using KafkaFlow.TypedHandler;
+
+services.AddKafka(kafka => kafka
+    .AddCluster(cluster => cluster
+        .WithBrokers(new[] { "localhost:9092" })
+        .AddConsumer(consumer => consumer
+            .Topic("topic-name")
+            .WithGroupId("sample-group")
+            .WithoutStoringOffsets()
             ...
         )
     )


### PR DESCRIPTION
# Description

- Creates WithoutStoringOffsets consumer option
- Admin and telemetry topics use only partition 0 of the topic
- Avoid storing offsets to Admin and Telemetry topics
- Fix NullReferenceException when a consumer starts
- Improve BatchConsume logic to avoid message loss
- Update Samples and Tests to use .NET 6.0 #322 

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
