### PR TITLE
Add MessagePack serializer

### DIFF
--- a/src/KafkaFlow.Admin.Dashboard/Properties/launchSettings.json
+++ b/src/KafkaFlow.Admin.Dashboard/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "KafkaFlow.Admin.Dashboard": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:52278;http://localhost:52279"
+    }
+  }
+}

--- a/src/KafkaFlow.Serializer.MessagePack/KafkaFlow.Serializer.MessagePack.csproj
+++ b/src/KafkaFlow.Serializer.MessagePack/KafkaFlow.Serializer.MessagePack.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<PackageId>KafkaFlow.Serializer.MessagePack</PackageId>
+		<Description>MessagePack implementation for KafkaFlow serializer middleware</Description>
+		<RootNamespace>KafkaFlow.Serializer</RootNamespace>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="MessagePack" Version="2.4.59" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\KafkaFlow.Abstractions\KafkaFlow.Abstractions.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/KafkaFlow.Serializer.MessagePack/MessagePackSerializer.cs
+++ b/src/KafkaFlow.Serializer.MessagePack/MessagePackSerializer.cs
@@ -1,0 +1,48 @@
+﻿namespace KafkaFlow.Serializer
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using MessagePack;
+    using MessagePack.Resolvers;
+
+    /// <summary>
+    /// A message serializer using MessagePack library
+    /// </summary>
+    public class MessagePackSerializer : ISerializer
+    {
+        private static readonly IFormatterResolver DefaultResolver = CompositeResolver.Create(
+                                                                        NativeDateTimeResolver.Instance,
+                                                                        StandardResolverAllowPrivate.Instance);
+
+        private readonly MessagePackSerializerOptions options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackSerializer"/> class.
+        /// </summary>
+        /// <param name="options">MessagePack serializer options</param>
+        public MessagePackSerializer(MessagePackSerializerOptions options)
+        {
+            this.options = options;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackSerializer"/> class.
+        /// </summary>
+        public MessagePackSerializer()
+            : this(MessagePackSerializerOptions
+                                .Standard
+                                .WithResolver(DefaultResolver)
+                                .WithCompression(MessagePackCompression.Lz4BlockArray))
+        {
+        }
+
+        /// <inheritdoc/>
+        public async Task<object> DeserializeAsync(Stream input, Type type, ISerializerContext context)
+            => await MessagePack.MessagePackSerializer.DeserializeAsync(type, input, this.options);
+
+        /// <inheritdoc/>
+        public Task SerializeAsync(object message, Stream output, ISerializerContext context)
+            => MessagePack.MessagePackSerializer.SerializeAsync(message.GetType(), output, message, this.options);
+    }
+}

--- a/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
+++ b/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
@@ -20,6 +20,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="MessagePack.Annotations" Version="2.4.59" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
@@ -31,6 +32,7 @@
         <ProjectReference Include="..\KafkaFlow.BatchConsume\KafkaFlow.BatchConsume.csproj" />
         <ProjectReference Include="..\KafkaFlow.Compressor\KafkaFlow.Compressor.csproj" />
         <ProjectReference Include="..\KafkaFlow.LogHandler.Microsoft\KafkaFlow.LogHandler.Microsoft.csproj" />
+        <ProjectReference Include="..\KafkaFlow.Serializer.MessagePack\KafkaFlow.Serializer.MessagePack.csproj" />
         <ProjectReference Include="..\KafkaFlow.Serializer\KafkaFlow.Serializer.csproj" />
         <ProjectReference Include="..\KafkaFlow.Serializer.NewtonsoftJson\KafkaFlow.Serializer.NewtonsoftJson.csproj" />
         <ProjectReference Include="..\KafkaFlow.TypedHandler\KafkaFlow.TypedHandler.csproj" />

--- a/src/KafkaFlow.UnitTests/Serializers/MessagePackSerializerTests.cs
+++ b/src/KafkaFlow.UnitTests/Serializers/MessagePackSerializerTests.cs
@@ -1,0 +1,77 @@
+namespace KafkaFlow.UnitTests.Serializers
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using AutoFixture;
+    using FluentAssertions;
+    using KafkaFlow.Serializer;
+    using MessagePack.Resolvers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class MessagePackSerializerTests
+    {
+        private static readonly MessagePack.MessagePackSerializerOptions MessagePackOptions = MessagePack.MessagePackSerializerOptions
+                                                                                                .Standard
+                                                                                                .WithResolver(CompositeResolver.Create(
+                                                                                                                NativeDateTimeResolver.Instance,
+                                                                                                                StandardResolverAllowPrivate.Instance))
+                                                                                                .WithCompression(MessagePack.MessagePackCompression.Lz4BlockArray);
+
+        private Mock<ISerializerContext> contextMock = new();
+
+        private MessagePackSerializer serializer = new(MessagePackOptions);
+
+        private Fixture fixture = new();
+
+        [TestMethod]
+        public async Task SerializeAsync_ValidPayload_JsonByteArrayGenerated()
+        {
+            // Arrange
+            var message = this.fixture.Create<TestMessage>();
+            using var output = new MemoryStream();
+
+            // Act
+            await this.serializer.SerializeAsync(message, output, this.contextMock.Object);
+
+            // Assert
+            output.Length.Should().BeGreaterThan(0);
+            output.Position.Should().BeGreaterThan(0);
+        }
+
+        [TestMethod]
+        public async Task DeserializeAsync_ValidPayload_ObjectGenerated()
+        {
+            // Arrange
+            var message = this.fixture.Create<TestMessage>();
+            using var input = new MemoryStream();
+            await MessagePack.MessagePackSerializer.SerializeAsync(message.GetType(), input, message, MessagePackOptions);
+            input.Seek(0, SeekOrigin.Begin);
+
+            // Act
+            var result = await this.serializer.DeserializeAsync(input, typeof(TestMessage), this.contextMock.Object);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<TestMessage>();
+        }
+
+        [MessagePack.MessagePackObject]
+        private class TestMessage
+        {
+            [MessagePack.Key(0)]
+            public int IntegerField { get; set; }
+
+            [MessagePack.Key(1)]
+            public string StringField { get; set; }
+
+            [MessagePack.Key(2)]
+            public double DoubleField { get; set; }
+
+            [MessagePack.Key(3)]
+            public DateTime DateTimeField { get; set; }
+        }
+    }
+}

--- a/src/KafkaFlow.sln
+++ b/src/KafkaFlow.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29709.97
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33103.184
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow", "KafkaFlow\KafkaFlow.csproj", "{E1055352-9F5B-4980-80A3-50C335B79A16}"
 EndProject
@@ -73,11 +73,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Serializer.Schema
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Admin.Dashboard", "KafkaFlow.Admin.Dashboard\KafkaFlow.Admin.Dashboard.csproj", "{4072F646-9393-4BF3-A479-0550AC1BB6C4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.Dashboard", "..\samples\KafkaFlow.Sample.Dashboard\KafkaFlow.Sample.Dashboard.csproj", "{F32DC7DA-36EA-4199-91F5-81960FD9C650}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Sample.Dashboard", "..\samples\KafkaFlow.Sample.Dashboard\KafkaFlow.Sample.Dashboard.csproj", "{F32DC7DA-36EA-4199-91F5-81960FD9C650}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.SchemaRegistry", "..\samples\KafkaFlow.Sample.SchemaRegistry\KafkaFlow.Sample.SchemaRegistry.csproj", "{2BD49C06-7A88-4B98-91B0-659282D2A45E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Sample.SchemaRegistry", "..\samples\KafkaFlow.Sample.SchemaRegistry\KafkaFlow.Sample.SchemaRegistry.csproj", "{2BD49C06-7A88-4B98-91B0-659282D2A45E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.FlowControl", "..\samples\KafkaFlow.Sample.FlowControl\KafkaFlow.Sample.FlowControl.csproj", "{7B61C99E-3AEB-4497-8A38-F780CB309130}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Sample.FlowControl", "..\samples\KafkaFlow.Sample.FlowControl\KafkaFlow.Sample.FlowControl.csproj", "{7B61C99E-3AEB-4497-8A38-F780CB309130}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{4A6A390C-A63A-4371-86BB-28481AD6D4C0}"
 	ProjectSection(SolutionItems) = preProject
@@ -85,7 +85,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{4A6A39
 		..\.github\workflows\publish.yml = ..\.github\workflows\publish.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.LogHandler.Microsoft", "KafkaFlow.LogHandler.Microsoft\KafkaFlow.LogHandler.Microsoft.csproj", "{8EAF0D96-F760-4FEF-9237-92779F66482D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.LogHandler.Microsoft", "KafkaFlow.LogHandler.Microsoft\KafkaFlow.LogHandler.Microsoft.csproj", "{8EAF0D96-F760-4FEF-9237-92779F66482D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Serializer.MessagePack", "KafkaFlow.Serializer.MessagePack\KafkaFlow.Serializer.MessagePack.csproj", "{F0444767-A81B-4CAC-BF12-F71E8C5FBECD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -213,6 +215,10 @@ Global
 		{8EAF0D96-F760-4FEF-9237-92779F66482D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8EAF0D96-F760-4FEF-9237-92779F66482D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8EAF0D96-F760-4FEF-9237-92779F66482D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0444767-A81B-4CAC-BF12-F71E8C5FBECD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0444767-A81B-4CAC-BF12-F71E8C5FBECD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0444767-A81B-4CAC-BF12-F71E8C5FBECD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0444767-A81B-4CAC-BF12-F71E8C5FBECD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -250,6 +256,7 @@ Global
 		{2BD49C06-7A88-4B98-91B0-659282D2A45E} = {303AE78F-6C96-4DF4-AC89-5C4FD53AFF0B}
 		{7B61C99E-3AEB-4497-8A38-F780CB309130} = {303AE78F-6C96-4DF4-AC89-5C4FD53AFF0B}
 		{8EAF0D96-F760-4FEF-9237-92779F66482D} = {EF626895-FDAE-4B28-9110-BA85671CBBF2}
+		{F0444767-A81B-4CAC-BF12-F71E8C5FBECD} = {ADAAA63C-E17C-4F1B-A062-3CCA071D75C2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6AE955B5-16B0-41CF-9F12-66D15B3DD1AB}


### PR DESCRIPTION
# Description

Add new project KafkaFlow.Serializer.MessagePack that use [MessagePack-CSharp](https://github.com/neuecc/MessagePack-CSharp) library to optimize message sizes.

## How Has This Been Tested?

I tested my changes using Program.cs of KafkaFlow.Sample.FlowControl, I made some changes to use MessagePack instead of NewtonsoftJson locally and runs ok. Also, I've added MessagePackSerializerTests project to unit tests.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
