### PR TITLE
fix: fix NullReferenceException when stopping

### DIFF
--- a/src/KafkaFlow/Consumers/DistributionStrategies/BytesSumDistributionStrategy.cs
+++ b/src/KafkaFlow/Consumers/DistributionStrategies/BytesSumDistributionStrategy.cs
@@ -28,9 +28,10 @@ namespace KafkaFlow.Consumers.DistributionStrategies
                 return Task.FromResult(this.workers[0]);
             }
 
-            return cancellationToken.IsCancellationRequested ?
-                null :
-                Task.FromResult(this.workers.ElementAtOrDefault(partitionKey.Sum(x => x) % this.workers.Count));
+            return Task.FromResult(
+                cancellationToken.IsCancellationRequested
+                    ? null
+                    : this.workers.ElementAtOrDefault(partitionKey.Sum(x => x) % this.workers.Count));
         }
     }
 }


### PR DESCRIPTION
# Description

Fix NullReferenceException when stopping the bus. The previous fix (https://github.com/Farfetch/kafkaflow/pull/282) failed at actually fixing the issue.

When the cancellation token is cancelled, the `GetWorkerAsync` method is returning a null `Task` instead of a null value (`Task.FromResult((IWorker)null)`). The calling code is throwing the exception when calling `ConfigureAwait(false)` on the task.

Fixes #256 

## How Has This Been Tested?

Manually against a service where the integration tests were constantly throwing the exception on exit.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
