### PR TITLE
docs: list messagepack serializer extension

### DIFF
--- a/website/src/pages/extensions/index.js
+++ b/website/src/pages/extensions/index.js
@@ -36,6 +36,15 @@ export default function Extensions() {
       ),
       link:'https://github.com/Farfetch/kafkaflow-retry-extensions'
     },
+    {
+      title: 'KafkaFlow MessagePack Serializer',
+      description: (
+        <>
+          KafkaFlow MessagePack Serializer is an extension of KafkaFlow that use the MessagePack-CSharp library to optimize message sizes.
+        </>
+      ),
+      link:'https://github.com/JotaDobleEse/kafkaflow-messagepack-serializer'
+    },
   ];
 
   const { siteConfig } = useDocusaurusContext();


### PR DESCRIPTION
# Description

Add [KafkaFlow MessagePack Serializer](https://github.com/JotaDobleEse/kafkaflow-messagepack-serializer) to the extensions list.

Related to: https://github.com/Farfetch/kafkaflow/pull/336

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
