### PR TITLE
Proper tombstone message consumption and batch consume bug fixes

### DIFF
--- a/src/KafkaFlow.Serializer/DefaultTypeResolver.cs
+++ b/src/KafkaFlow.Serializer/DefaultTypeResolver.cs
@@ -10,7 +10,9 @@ namespace KafkaFlow
         {
             var typeName = context.Headers.GetString(MessageType);
 
-            return Type.GetType(typeName);
+            return typeName is null ?
+                null :
+                Type.GetType(typeName);
         }
 
         public void OnProduce(IMessageContext context)

--- a/src/KafkaFlow.TypedHandler/HandlerTypeMapping.cs
+++ b/src/KafkaFlow.TypedHandler/HandlerTypeMapping.cs
@@ -2,10 +2,11 @@ namespace KafkaFlow.TypedHandler
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     internal class HandlerTypeMapping
     {
+        private static readonly IReadOnlyList<Type> EmptyList = new List<Type>().AsReadOnly();
+
         private readonly Dictionary<Type, List<Type>> mapping = new();
 
         public void AddMapping(Type messageType, Type handlerType)
@@ -19,11 +20,16 @@ namespace KafkaFlow.TypedHandler
             handlers.Add(handlerType);
         }
 
-        public IEnumerable<Type> GetHandlersTypes(Type messageType)
+        public IReadOnlyList<Type> GetHandlersTypes(Type messageType)
         {
+            if (messageType is null)
+            {
+                return EmptyList;
+            }
+
             return this.mapping.TryGetValue(messageType, out var handlerType) ?
                 handlerType :
-                Enumerable.Empty<Type>();
+                EmptyList;
         }
     }
 }

--- a/src/KafkaFlow.TypedHandler/TypedHandlerMiddleware.cs
+++ b/src/KafkaFlow.TypedHandler/TypedHandlerMiddleware.cs
@@ -20,7 +20,7 @@ namespace KafkaFlow.TypedHandler
         {
             var handlers = this.configuration
                 .HandlerMapping
-                .GetHandlersTypes(context.Message.Value.GetType());
+                .GetHandlersTypes(context.Message.Value?.GetType());
 
             if (!handlers.Any())
             {


### PR DESCRIPTION
# Description

- Deserialize tombstone messages as a null object
- Better exception handling on consumer worker
- Fix #359


## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
