### PR TITLE
Remove exception when some topic are created and some are already exists

### DIFF
--- a/src/KafkaFlow/Clusters/ClusterManager.cs
+++ b/src/KafkaFlow/Clusters/ClusterManager.cs
@@ -45,7 +45,7 @@ namespace KafkaFlow.Clusters
             catch (CreateTopicsException exception)
             {
                 var hasNonExpectedErrors = false;
-                foreach (var exceptionResult in exception.Results)
+                foreach (var exceptionResult in exception.Results.Where(report => report.Error.IsError))
                 {
                     if (exceptionResult.Error.Code == ErrorCode.TopicAlreadyExists)
                     {


### PR DESCRIPTION
# Description

When using `CreateTopicIfNotExists` for multiple topics if some of them already exists - KafkaFlow will throw exception because `CreateTopicsException` contains all results - successful and failed. `ClusterManager` perfrom check for `non expected errors` and mark success results as such.

## How Has This Been Tested?

It's easy to reproduce:

```cs
var servers = new[] { "127.0.0.1:9092" };
var topic = "TestTopic" + Guid.NewGuid();
// configure first bus to create main topic
var services = new ServiceCollection();
services
    .AddKafka(
        kafka => kafka
            .UseConsoleLog()
            .AddCluster(
                cluster =>
                {
                    cluster.WithBrokers(servers);
                    cluster.CreateTopicIfNotExists(topic, 4, 1);
                }));

var serviceProvider = services.BuildServiceProvider();
var bus = serviceProvider.CreateKafkaBus();

Console.WriteLine("Start first bus");
await bus.StartAsync(); // topic created
// configure second bus to create main and secondary topic
var services2 = new ServiceCollection();
services2
    .AddKafka(
        kafka => kafka
            .UseConsoleLog()
            .AddCluster(
                cluster =>
                {
                    cluster.WithBrokers(servers);
                    cluster.CreateTopicIfNotExists(topic, 4, 1);
                    cluster.CreateTopicIfNotExists(topic+1, 4, 1);
                }));
var serviceProvider2 = services2.BuildServiceProvider();
var bus2 = serviceProvider2.CreateKafkaBus();

Console.WriteLine("Start second bus");
await bus2.StartAsync(); // Exception
```

will results in exception:

```
KafkaFlow: An error occurred creating topics | Data: {"Servers":["127.0.0.1:9092"]} | Exception: {"Type":"Confluent.Kafka.Admin.CreateTopicsException","Message":"An error occurred creating topics: [TestTopic125dc590-9c84-4669-bea7-51bc72efc1e7]: [Topic \u0027TestTopic125dc590-9c84-4669-bea7-51bc72efc1e7\u00
27 already exists.].","StackTrace":"   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()\r\n   at KafkaFlow.Clusters.Cluste
rManager.\u003CCreateIfNotExistsAsync\u003Ed__6.MoveNext() in KafkaFlow\\Clusters\\ClusterManager.cs:line 44"}

Unhandled Exception: Confluent.Kafka.Admin.CreateTopicsException: An error occurred creating topics: [TestTopic125dc590-9c84-4669-bea7-51bc72efc1e7]: [Topic 'TestTopic125dc590-9c84-4669-bea7-51bc72efc1e7' already exists.].
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at KafkaFlow.Clusters.ClusterManager.<CreateIfNotExistsAsync>d__6.MoveNext() in KafkaFlow\Clusters\ClusterManager.cs:line 78
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at KafkaFlow.KafkaBus.<CreateMissingClusterTopics>d__14.MoveNext() in KafkaFlow\KafkaBus.cs:line 91
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at KafkaFlow.KafkaBus.<StartAsync>d__12.MoveNext() in KafkaFlow\KafkaBus.cs:line 49
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Program.<<Main>$>d__0.MoveNext() in Program.cs:line 40
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Program.<Main>(String[] args)
```

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
