### PR TITLE
fix: accept null as message key

### DIFF
--- a/src/KafkaFlow.IntegrationTests/ProducerTest.cs
+++ b/src/KafkaFlow.IntegrationTests/ProducerTest.cs
@@ -1,0 +1,41 @@
+namespace KafkaFlow.IntegrationTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AutoFixture;
+    using KafkaFlow.IntegrationTests.Core;
+    using KafkaFlow.IntegrationTests.Core.Handlers;
+    using KafkaFlow.IntegrationTests.Core.Producers;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ProducerTest
+    {
+        private readonly Fixture fixture = new();
+
+        private IServiceProvider provider;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.provider = Bootstrapper.GetServiceProvider();
+            MessageStorage.Clear();
+        }
+
+
+        [TestMethod]
+        public async Task ProduceNullKeyTest()
+        {
+            // Arrange
+            var producer = this.provider.GetRequiredService<IMessageProducer<GzipProducer>>();
+            var message = this.fixture.Create<byte[]>();
+
+            // Act
+            await producer.ProduceAsync(null, message);
+
+            // Assert
+            await MessageStorage.AssertMessageAsync(message);
+        }
+    }
+}

--- a/src/KafkaFlow/Producers/MessageProducer.cs
+++ b/src/KafkaFlow/Producers/MessageProducer.cs
@@ -186,6 +186,7 @@ namespace KafkaFlow.Producers
             {
                 string stringKey => Encoding.UTF8.GetBytes(stringKey),
                 byte[] bytesKey => bytesKey,
+                null => null,
                 _ => throw new InvalidOperationException(
                     $"The message key must be a byte array or a string to be produced, it is a {context.Message.Key.GetType().FullName}." +
                     "You should serialize or encode your message object using a middleware")

--- a/website/docs/guides/producers.md
+++ b/website/docs/guides/producers.md
@@ -125,6 +125,14 @@ services.AddKafka(kafka => kafka
 );
 ```
 
+## How to produce a message without Message Key
+
+You can send the message key argument as `null` when the Produce method is invoked, as shown in the following example:
+
+```csharp
+await producer.ProduceAsync(null, product);
+```      
+
 ## How to configure ACKS when publishing a message
 
 An Ack is an acknowledgment that the producer receives from the broker to ensure that the message has been successfully committed.


### PR DESCRIPTION
# Description

Support publishing messages with `null` message key, so Kafka can use round-robin to pick partitions.

```csharp
            await producer.ProduceAsync(null, message);
```

Fixes #373

## How Has This Been Tested?

Added an Integration Test.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
