### PR TITLE
Deduplicate topic declaration before trying to create them

### DIFF
--- a/src/KafkaFlow/Clusters/ClusterManager.cs
+++ b/src/KafkaFlow/Clusters/ClusterManager.cs
@@ -30,6 +30,7 @@ namespace KafkaFlow.Clusters
             try
             {
                 var topics = configurations
+                    .Distinct(new DuplicateTopicConfigurationEqualityComparer())
                     .Select(
                         topicConfiguration => new TopicSpecification
                         {
@@ -74,6 +75,13 @@ namespace KafkaFlow.Clusters
                     throw;
                 }
             }
+        }
+
+        private class DuplicateTopicConfigurationEqualityComparer : IEqualityComparer<TopicConfiguration>
+        {
+            public bool Equals(TopicConfiguration x, TopicConfiguration y) => x?.Name == y?.Name;
+
+            public int GetHashCode(TopicConfiguration obj) => obj.Name.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
# Description

Deduplicate topic list before sending it to AdminClient. Handle case where client call multiple CreateTopicIfNotExists with same topic name.

Fixes #382

## How Has This Been Tested?

Tested on our solution

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
