### PR TITLE
docs: add kafkaflow.mediatr to extension list

### DIFF
--- a/website/src/pages/extensions/index.js
+++ b/website/src/pages/extensions/index.js
@@ -45,6 +45,15 @@ export default function Extensions() {
       ),
       link:'https://github.com/JotaDobleEse/kafkaflow-messagepack-serializer'
     },
+    {
+      title: 'KafkaFlow.MediatR',
+      description: (
+        <>
+          An Extension that adds MediatR as a Middleware.
+        </>
+      ),
+      link:'https://github.com/gsferreira/kafkaflow-mediatr'
+    },
   ];
 
   const { siteConfig } = useDocusaurusContext();


### PR DESCRIPTION
# Description

List extension [KafkaFlow.MediatR](https://github.com/gsferreira/kafkaflow-mediatr).

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
