### PR TITLE
Use CsharpNamespace when Package is empty in ConfluentProtobufTypeResolver

### DIFF
--- a/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/AssemblyInfo.cs
+++ b/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("KafkaFlow.UnitTests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/ConfluentProtobufTypeNameResolver.cs
+++ b/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/ConfluentProtobufTypeNameResolver.cs
@@ -6,7 +6,7 @@ namespace KafkaFlow
     using Google.Protobuf;
     using Google.Protobuf.Reflection;
 
-    internal class ConfluentProtobufTypeNameResolver : IAsyncSchemaRegistryTypeNameResolver
+    internal sealed class ConfluentProtobufTypeNameResolver : IAsyncSchemaRegistryTypeNameResolver
     {
         private readonly ISchemaRegistryClient client;
 

--- a/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/ConfluentProtobufTypeNameResolver.cs
+++ b/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/ConfluentProtobufTypeNameResolver.cs
@@ -21,7 +21,18 @@ namespace KafkaFlow
 
             var protoFields = FileDescriptorProto.Parser.ParseFrom(ByteString.FromBase64(schemaString));
 
-            return $"{protoFields.Package}.{protoFields.MessageType.FirstOrDefault()?.Name}";
+            return BuildTypeName(protoFields);
+        }
+
+        private static string BuildTypeName(FileDescriptorProto protoFields)
+        {
+            var package = protoFields.Package;
+            if (string.IsNullOrEmpty(package))
+            {
+                package = protoFields.Options.CsharpNamespace;
+            }
+
+            return $"{package}.{protoFields.MessageType.FirstOrDefault()?.Name}";
         }
     }
 }

--- a/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
+++ b/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
@@ -25,6 +25,8 @@
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+        <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.3" />
+        <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.9.3" />
     </ItemGroup>
 
     <ItemGroup>
@@ -32,6 +34,7 @@
         <ProjectReference Include="..\KafkaFlow.BatchConsume\KafkaFlow.BatchConsume.csproj" />
         <ProjectReference Include="..\KafkaFlow.Compressor\KafkaFlow.Compressor.csproj" />
         <ProjectReference Include="..\KafkaFlow.LogHandler.Microsoft\KafkaFlow.LogHandler.Microsoft.csproj" />
+        <ProjectReference Include="..\KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf\KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf.csproj" />
         <ProjectReference Include="..\KafkaFlow.Serializer\KafkaFlow.Serializer.csproj" />
         <ProjectReference Include="..\KafkaFlow.Serializer.NewtonsoftJson\KafkaFlow.Serializer.NewtonsoftJson.csproj" />
         <ProjectReference Include="..\KafkaFlow.TypedHandler\KafkaFlow.TypedHandler.csproj" />

--- a/src/KafkaFlow.UnitTests/Serializers/ConfluentProtobufTypeNameResolverTests.cs
+++ b/src/KafkaFlow.UnitTests/Serializers/ConfluentProtobufTypeNameResolverTests.cs
@@ -1,0 +1,74 @@
+namespace KafkaFlow.UnitTests.Serializers
+{
+    using System;
+    using System.Threading.Tasks;
+    using Confluent.SchemaRegistry;
+    using FluentAssertions;
+    using Google.Protobuf;
+    using Google.Protobuf.Reflection;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class ConfluentProtobufTypeNameResolverTests
+    {
+        private const string MessageTypeName = "TestMessage";
+
+        [TestMethod]
+        public async Task ResolveAsync_WithPackage_ReturnTypeName()
+        {
+            // Arrange
+            var schemaRegistryClientMock = CreateSchemaRegistryClientMock(p => p.Package = "TestPackage");
+            var resolver = new ConfluentProtobufTypeNameResolver(schemaRegistryClientMock.Object);
+
+            // Act
+            var typeName = await resolver.ResolveAsync(1);
+
+            // Assert
+            typeName.Should().Be($"TestPackage.{MessageTypeName}");
+        }
+
+        [TestMethod]
+        public async Task ResolveAsync_NoPackageWithCsharpNamespace_ReturnTypeName()
+        {
+            // Arrange
+            var schemaRegistryClientMock = CreateSchemaRegistryClientMock(p =>
+            {
+                p.Package = string.Empty;
+                p.Options.CsharpNamespace = "TestCsharpNamespace";
+            });
+            var resolver = new ConfluentProtobufTypeNameResolver(schemaRegistryClientMock.Object);
+
+            // Act
+            var typeName = await resolver.ResolveAsync(1);
+
+            // Assert
+            typeName.Should().Be($"TestCsharpNamespace.{MessageTypeName}");
+        }
+
+        private static Mock<ISchemaRegistryClient> CreateSchemaRegistryClientMock(Action<FileDescriptorProto> configure)
+        {
+            var protoFields = new FileDescriptorProto
+            {
+                MessageType =
+                {
+                    new DescriptorProto
+                    {
+                        Name = MessageTypeName,
+                    },
+                },
+                Options = new FileOptions(),
+            };
+            configure(protoFields);
+
+            var schema = new Schema(protoFields.ToByteString().ToBase64(), SchemaType.Protobuf);
+
+            var schemaRegistryClientMock = new Mock<ISchemaRegistryClient>();
+            schemaRegistryClientMock
+                .Setup(o => o.GetSchemaAsync(1, "serialized"))
+                .ReturnsAsync(schema);
+
+            return schemaRegistryClientMock;
+        }
+    }
+}

--- a/src/KafkaFlow.UnitTests/Serializers/SchemaRegistry/ConfluentProtobufTypeNameResolverTests.cs
+++ b/src/KafkaFlow.UnitTests/Serializers/SchemaRegistry/ConfluentProtobufTypeNameResolverTests.cs
@@ -1,4 +1,4 @@
-namespace KafkaFlow.UnitTests.Serializers
+namespace KafkaFlow.UnitTests.Serializers.SchemaRegistry
 {
     using System;
     using System.Threading.Tasks;


### PR DESCRIPTION
# Description

This pull request is a basic implementation of the issue addressed here: https://github.com/Farfetch/kafkaflow/issues/404

## How Has This Been Tested?

Unit tests for `ConfluentProtobufTypeResolver` has been created (`ConfluentProtobufTypeNameResolverTests`).

Two cases are tested there, one when `Package` is non-empty and the second when `Package` is empty but `CsharpNamespace` is available.

## Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [X] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
