### PR TITLE
fix: add security config to admin client builder

### DIFF
--- a/src/KafkaFlow/Clusters/ClusterManager.cs
+++ b/src/KafkaFlow/Clusters/ClusterManager.cs
@@ -13,13 +13,15 @@ namespace KafkaFlow.Clusters
         private readonly ILogHandler logHandler;
         private readonly Lazy<AdminClientBuilder> lazyAdminClientBuilder;
         private readonly ClusterConfiguration configuration;
+        private readonly ClientConfig clientConfig = new();
 
         public ClusterManager(ILogHandler logHandler, ClusterConfiguration configuration)
         {
             this.logHandler = logHandler;
             this.configuration = configuration;
+            this.clientConfig.ReadSecurityInformationFrom(this.configuration);
             this.lazyAdminClientBuilder = new Lazy<AdminClientBuilder>(
-                () => new AdminClientBuilder(new AdminClientConfig
+                () => new AdminClientBuilder(new AdminClientConfig(this.clientConfig)
                 { BootstrapServers = string.Join(",", configuration.Brokers) }));
         }
 

--- a/src/KafkaFlow/Clusters/ClusterManager.cs
+++ b/src/KafkaFlow/Clusters/ClusterManager.cs
@@ -13,16 +13,22 @@ namespace KafkaFlow.Clusters
         private readonly ILogHandler logHandler;
         private readonly Lazy<AdminClientBuilder> lazyAdminClientBuilder;
         private readonly ClusterConfiguration configuration;
-        private readonly ClientConfig clientConfig = new();
 
         public ClusterManager(ILogHandler logHandler, ClusterConfiguration configuration)
         {
             this.logHandler = logHandler;
             this.configuration = configuration;
-            this.clientConfig.ReadSecurityInformationFrom(this.configuration);
             this.lazyAdminClientBuilder = new Lazy<AdminClientBuilder>(
-                () => new AdminClientBuilder(new AdminClientConfig(this.clientConfig)
-                { BootstrapServers = string.Join(",", configuration.Brokers) }));
+                () =>
+                {
+                    var adminConfig = new AdminClientConfig()
+                    {
+                        BootstrapServers = string.Join(",", configuration.Brokers),
+                    };
+                    adminConfig.ReadSecurityInformationFrom(configuration);
+
+                    return new AdminClientBuilder(adminConfig);
+                });
         }
 
         public string ClusterName => this.configuration.Name;

--- a/src/KafkaFlow/Clusters/ClusterManager.cs
+++ b/src/KafkaFlow/Clusters/ClusterManager.cs
@@ -21,7 +21,7 @@ namespace KafkaFlow.Clusters
             this.lazyAdminClientBuilder = new Lazy<AdminClientBuilder>(
                 () =>
                 {
-                    var adminConfig = new AdminClientConfig()
+                    var adminConfig = new AdminClientConfig
                     {
                         BootstrapServers = string.Join(",", configuration.Brokers),
                     };


### PR DESCRIPTION
# Description

Pass security configuration to the `lazyAdminClientBuilder` 

Fixes #397 

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

