### PR TITLE
[Bug Report]:  Kafkaflow does not allow to have consumers with different consumer groups

### DIFF
--- a/src/KafkaFlow.IntegrationTests/ConsumerTest.cs
+++ b/src/KafkaFlow.IntegrationTests/ConsumerTest.cs
@@ -6,6 +6,7 @@ namespace KafkaFlow.IntegrationTests
     using AutoFixture;
     using global::Microsoft.Extensions.DependencyInjection;
     using global::Microsoft.VisualStudio.TestTools.UnitTesting;
+    using KafkaFlow.Consumers;
     using KafkaFlow.IntegrationTests.Core;
     using KafkaFlow.IntegrationTests.Core.Handlers;
     using KafkaFlow.IntegrationTests.Core.Messages;
@@ -140,6 +141,22 @@ namespace KafkaFlow.IntegrationTests
             {
                 await MessageStorage.AssertMessageAsync(message);
             }
+        }
+
+        [TestMethod]
+        public void AddConsumer_WithSharedConsumerConfig_ConsumersAreConfiguratedIndependently()
+        {
+            // Act
+            var consumers = this.provider.GetRequiredService<IConsumerAccessor>().All;
+
+            // Assert
+            Assert.IsNotNull(consumers.FirstOrDefault(x => x.GroupId.Equals(Bootstrapper.AvroGroupId)));
+            Assert.IsNotNull(consumers.FirstOrDefault(x => x.GroupId.Equals(Bootstrapper.GzipGroupId)));
+            Assert.IsNotNull(consumers.FirstOrDefault(x => x.GroupId.Equals(Bootstrapper.JsonGroupId)));
+            Assert.IsNotNull(consumers.FirstOrDefault(x => x.GroupId.Equals(Bootstrapper.JsonGzipGroupId)));
+            Assert.IsNotNull(consumers.FirstOrDefault(x => x.GroupId.Equals(Bootstrapper.PauseResumeGroupId)));
+            Assert.IsNotNull(consumers.FirstOrDefault(x => x.GroupId.Equals(Bootstrapper.ProtobufGroupId)));
+            Assert.IsNotNull(consumers.FirstOrDefault(x => x.GroupId.Equals(Bootstrapper.ProtobufGzipGroupId)));
         }
     }
 }

--- a/src/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
+++ b/src/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
@@ -25,6 +25,14 @@ namespace KafkaFlow.IntegrationTests.Core
         public const string PauseResumeTopicName = "test-pause-resume";
         public const int MaxPollIntervalMs = 7000;
 
+        internal const string ProtobufGroupId = "consumer-protobuf";
+        internal const string GzipGroupId = "consumer-gzip";
+        internal const string JsonGzipGroupId = "consumer-json-gzip";
+        internal const string ProtobufGzipGroupId = "consumer-protobuf-gzip";
+        internal const string PauseResumeGroupId = "consumer-pause-resume";
+        internal const string AvroGroupId = "consumer-avro";
+        internal const string JsonGroupId = "consumer-json";
+
         private const string ProtobufTopicName = "test-protobuf";
         private const string ProtobufSchemaRegistryTopicName = "test-protobuf-sr";
         private const string JsonSchemaRegistryTopicName = "test-json-sr";
@@ -34,12 +42,6 @@ namespace KafkaFlow.IntegrationTests.Core
         private const string ProtobufGzipTopicName = "test-protobuf-gzip";
         private const string ProtobufGzipTopicName2 = "test-protobuf-gzip-2";
         private const string AvroTopicName = "test-avro";
-
-        private const string ProtobufGroupId = "consumer-protobuf";
-        private const string GzipGroupId = "consumer-gzip";
-        private const string JsonGzipGroupId = "consumer-json-gzip";
-        private const string ProtobufGzipGroupId = "consumer-protobuf-gzip";
-        private const string PauseResumeGroupId = "consumer-pause-resume";
 
         private static readonly Lazy<IServiceProvider> LazyProvider = new(SetupProvider);
 
@@ -83,6 +85,17 @@ namespace KafkaFlow.IntegrationTests.Core
             var kafkaBrokers = context.Configuration.GetValue<string>("Kafka:Brokers");
             var schemaRegistryUrl = context.Configuration.GetValue<string>("SchemaRegistry:Url");
 
+            ConsumerConfig defaultConfig = new()
+            {
+                Acks = Confluent.Kafka.Acks.All,
+                AllowAutoCreateTopics = false,
+                AutoCommitIntervalMs = 5000,
+                AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Latest,
+                LogConnectionClose = false,
+                ReconnectBackoffMs = 1000,
+                ReconnectBackoffMaxMs = 6000
+            };
+
             services.AddKafka(
                 kafka => kafka
                     .UseLogHandler<TraceLogHandler>()
@@ -109,10 +122,11 @@ namespace KafkaFlow.IntegrationTests.Core
                             .AddConsumer(
                                 consumer => consumer
                                     .Topic(AvroTopicName)
-                                    .WithGroupId("consumer-avro")
+                                    .WithGroupId(AvroGroupId)
                                     .WithBufferSize(100)
                                     .WithWorkersCount(10)
                                     .WithAutoOffsetReset(AutoOffsetReset.Latest)
+                                    .WithConsumerConfig(defaultConfig)
                                     .AddMiddlewares(
                                         middlewares => middlewares
                                             .AddSerializer<ConfluentAvroSerializer>()
@@ -136,10 +150,11 @@ namespace KafkaFlow.IntegrationTests.Core
                             .AddConsumer(
                                 consumer => consumer
                                     .Topic(ProtobufSchemaRegistryTopicName)
-                                    .WithGroupId("consumer-protobuf")
+                                    .WithGroupId(ProtobufGroupId)
                                     .WithBufferSize(100)
                                     .WithWorkersCount(10)
                                     .WithAutoOffsetReset(AutoOffsetReset.Latest)
+                                    .WithConsumerConfig(defaultConfig)
                                     .AddMiddlewares(
                                         middlewares => middlewares
                                             .AddSerializer<ConfluentProtobufSerializer>()
@@ -163,10 +178,11 @@ namespace KafkaFlow.IntegrationTests.Core
                             .AddConsumer(
                                 consumer => consumer
                                     .Topic(JsonSchemaRegistryTopicName)
-                                    .WithGroupId("consumer-json")
+                                    .WithGroupId(JsonGroupId)
                                     .WithBufferSize(100)
                                     .WithWorkersCount(10)
                                     .WithAutoOffsetReset(AutoOffsetReset.Latest)
+                                    .WithConsumerConfig(defaultConfig)
                                     .AddMiddlewares(
                                         middlewares => middlewares
                                             .AddSerializer<ConfluentJsonSerializer>()

--- a/src/KafkaFlow.UnitTests/ConfigurationBuilders/ConsumerConfigurationBuilderTests.cs
+++ b/src/KafkaFlow.UnitTests/ConfigurationBuilders/ConsumerConfigurationBuilderTests.cs
@@ -88,7 +88,10 @@ namespace KafkaFlow.UnitTests.ConfigurationBuilders
             Action<IDependencyResolver, List<TopicPartition>> partitionsAssignedHandler = (_, _) => { };
             Action<IDependencyResolver, List<TopicPartitionOffset>> partitionsRevokedHandler = (_, _) => { };
             const int statisticsIntervalMs = 100;
-            var consumerConfig = new ConsumerConfig();
+            var consumerConfig = new ConsumerConfig
+            {
+                ClientId = "testeclient"
+            };
 
             this.target
                 .Topics(topic1)
@@ -128,7 +131,7 @@ namespace KafkaFlow.UnitTests.ConfigurationBuilders
             configuration.StatisticsHandlers.Should().HaveElementAt(0, statisticsHandler);
             configuration.PartitionsAssignedHandlers.Should().HaveElementAt(0, partitionsAssignedHandler);
             configuration.PartitionsRevokedHandlers.Should().HaveElementAt(0, partitionsRevokedHandler);
-            configuration.GetKafkaConfig().Should().BeSameAs(consumerConfig);
+            configuration.GetKafkaConfig().ClientId.Should().Be(consumerConfig.ClientId);
             configuration.MiddlewaresConfigurations.Should().HaveCount(1);
         }
     }

--- a/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
@@ -234,19 +234,22 @@ namespace KafkaFlow.Configuration
             var middlewareConfiguration = this.middlewareConfigurationBuilder.Build();
 
             this.consumerConfig ??= new ConsumerConfig();
-            this.consumerConfig.BootstrapServers ??= string.Join(",", clusterConfiguration.Brokers);
-            this.consumerConfig.GroupId ??= this.groupId;
-            this.consumerConfig.AutoOffsetReset ??= this.autoOffsetReset;
-            this.consumerConfig.MaxPollIntervalMs ??= this.maxPollIntervalMs;
-            this.consumerConfig.StatisticsIntervalMs ??= this.statisticsInterval;
 
-            this.consumerConfig.EnableAutoOffsetStore = false;
-            this.consumerConfig.EnableAutoCommit = false;
+            var consumerConfigCopy = new ConsumerConfig(this.consumerConfig.ToDictionary(x => x.Key, x => x.Value));
 
-            this.consumerConfig.ReadSecurityInformationFrom(clusterConfiguration);
+            consumerConfigCopy.BootstrapServers = this.consumerConfig.BootstrapServers ?? string.Join(",", clusterConfiguration.Brokers);
+            consumerConfigCopy.GroupId = this.consumerConfig.GroupId ?? this.groupId;
+            consumerConfigCopy.AutoOffsetReset = this.consumerConfig.AutoOffsetReset ?? this.autoOffsetReset;
+            consumerConfigCopy.MaxPollIntervalMs = this.consumerConfig.MaxPollIntervalMs ?? this.maxPollIntervalMs;
+            consumerConfigCopy.StatisticsIntervalMs = this.consumerConfig.StatisticsIntervalMs ?? this.statisticsInterval;
+
+            consumerConfigCopy.EnableAutoOffsetStore = false;
+            consumerConfigCopy.EnableAutoCommit = false;
+
+            consumerConfigCopy.ReadSecurityInformationFrom(clusterConfiguration);
 
             return new ConsumerConfiguration(
-                this.consumerConfig,
+                consumerConfigCopy,
                 this.topics,
                 this.topicsPartitions,
                 this.name,


### PR DESCRIPTION
# Description

`ConsumerConfig` was being referenced between consumers. This fix creates each consumer with `ConsumerConfig` in an isolated way.

Fixes # (issue)

fix https://github.com/Farfetch/kafkaflow/issues/410

## Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation
