### PR TITLE
Support for customizing JsonWriterOptions in JsonCoreSerializer

### DIFF
--- a/src/KafkaFlow.Serializer.JsonCore/JsonCoreSerializer.cs
+++ b/src/KafkaFlow.Serializer.JsonCore/JsonCoreSerializer.cs
@@ -10,7 +10,8 @@
     /// </summary>
     public class JsonCoreSerializer : ISerializer
     {
-        private readonly JsonSerializerOptions options;
+        private readonly JsonSerializerOptions serializerOptions;
+        private readonly JsonWriterOptions writerOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonCoreSerializer"/> class.
@@ -18,23 +19,43 @@
         /// <param name="options">Json serializer options</param>
         public JsonCoreSerializer(JsonSerializerOptions options)
         {
-            this.options = options;
+            this.serializerOptions = options;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonCoreSerializer"/> class.
+        /// </summary>
+        /// <param name="writerOptions">Json writer options</param>
+        public JsonCoreSerializer(JsonWriterOptions writerOptions)
+        {
+            this.writerOptions = writerOptions;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonCoreSerializer"/> class.
+        /// </summary>
+        /// <param name="serializerOptions">Json serializer options</param>
+        /// <param name="writerOptions">Json writer options</param>
+        public JsonCoreSerializer(JsonSerializerOptions serializerOptions, JsonWriterOptions writerOptions)
+        {
+            this.serializerOptions = serializerOptions;
+            this.writerOptions = writerOptions;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonCoreSerializer"/> class.
         /// </summary>
         public JsonCoreSerializer()
-            : this(new JsonSerializerOptions())
+            : this(new JsonSerializerOptions(), default)
         {
         }
 
         /// <inheritdoc/>
         public Task SerializeAsync(object message, Stream output, ISerializerContext context)
         {
-            using var writer = new Utf8JsonWriter(output);
+            using var writer = new Utf8JsonWriter(output, this.writerOptions);
 
-            JsonSerializer.Serialize(writer, message, this.options);
+            JsonSerializer.Serialize(writer, message, this.serializerOptions);
 
             return Task.CompletedTask;
         }
@@ -43,7 +64,7 @@
         public async Task<object> DeserializeAsync(Stream input, Type type, ISerializerContext context)
         {
             return await JsonSerializer
-                .DeserializeAsync(input, type, this.options)
+                .DeserializeAsync(input, type, this.serializerOptions)
                 .ConfigureAwait(false);
         }
     }

--- a/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
+++ b/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
@@ -32,6 +32,7 @@
         <ProjectReference Include="..\KafkaFlow.BatchConsume\KafkaFlow.BatchConsume.csproj" />
         <ProjectReference Include="..\KafkaFlow.Compressor\KafkaFlow.Compressor.csproj" />
         <ProjectReference Include="..\KafkaFlow.LogHandler.Microsoft\KafkaFlow.LogHandler.Microsoft.csproj" />
+        <ProjectReference Include="..\KafkaFlow.Serializer.JsonCore\KafkaFlow.Serializer.JsonCore.csproj" />
         <ProjectReference Include="..\KafkaFlow.Serializer\KafkaFlow.Serializer.csproj" />
         <ProjectReference Include="..\KafkaFlow.Serializer.NewtonsoftJson\KafkaFlow.Serializer.NewtonsoftJson.csproj" />
         <ProjectReference Include="..\KafkaFlow.TypedHandler\KafkaFlow.TypedHandler.csproj" />

--- a/src/KafkaFlow.UnitTests/Serializers/JsonCoreSerializerTests.cs
+++ b/src/KafkaFlow.UnitTests/Serializers/JsonCoreSerializerTests.cs
@@ -1,0 +1,48 @@
+﻿namespace KafkaFlow.UnitTests.Serializers
+{
+    using System.IO;
+    using System.Text.Encodings.Web;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using KafkaFlow.Serializer;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class JsonCoreSerializerTests
+    {
+        private readonly Mock<ISerializerContext> contextMock = new();
+
+        [TestMethod]
+        public async Task SerializeAsync_PreventEscapeOfAccentedCharacter_SerializedObjectDoesNotHaveAccentedCharacterEscaped()
+        {
+            // Arrange
+            var message = new TestMessage { Text = "Café Façade" };
+            using var output = new MemoryStream();
+
+            var writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
+            var target = new JsonCoreSerializer(writerOptions);
+
+            // Act
+            await target.SerializeAsync(message, output, this.contextMock.Object);
+
+            // Assert
+            var result = GetStreamText(output);
+            result.Should().Contain("Café Façade");
+        }
+
+        private static string GetStreamText(MemoryStream output)
+        {
+            output.Position = 0;
+            var reader = new StreamReader(output);
+            return reader.ReadToEnd();
+        }
+
+        private class TestMessage
+        {
+            public string Text { get; set; }
+        }
+    }
+}


### PR DESCRIPTION

# Description

The reason why accented characters were being escaped was because the stream writer was escaping those characters.

The JsonCoreSerializer only accepted customization of JsonSerializerOptions and while this allows to prevent the escape of accented characters during the serialization process, nevertheless when writing the the steam the accented characters were still being escaped.

To fix this, it was added new constructors to JsonCoreSerializer to customize the JsonWriterOptions in order to allow to specify that accented characters should not be escaped when writing to the stream.

Fixes #414 

## How Has This Been Tested?

Unit tests were added to validate that the fix is working as expected.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
