### PR TITLE
docs: remove authors from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,6 @@ Learn more about using KafkaFlow on the [site](https://farfetch.github.io/kafkaf
 
 Read our [contributing guidelines](CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes.
 
-## Authors
-
--   [filipeesch](https://github.com/filipeesch)
--   [dougolima](https://github.com/dougolima)
-
 ## Get in touch
 
 You can find us at:


### PR DESCRIPTION
# Description

Remove the list of authors from README.md.

Reason: In a company-supported open-source project, the need for such a list doesn't bring value as in other open-source projects. The author is FARFETCH and also the maintainers can easily be found.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
