### PR TITLE
Include Open Telemetry tracing

### DIFF
--- a/samples/KafkaFlow.Sample/KafkaFlow.Sample.csproj
+++ b/samples/KafkaFlow.Sample/KafkaFlow.Sample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>

--- a/src/KafkaFlow.Abstractions/Configuration/IGlobalEvents.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/IGlobalEvents.cs
@@ -1,0 +1,38 @@
+﻿namespace KafkaFlow.Configuration
+{
+    /// <summary>
+    /// Provides access to events fired by the internals of the library
+    /// </summary>
+    public interface IGlobalEvents
+    {
+        /// <summary>
+        /// Gets the message consume completed event
+        /// </summary>
+        IEvent<MessageEventContext> MessageConsumeCompleted { get; }
+
+        /// <summary>
+        /// Gets the message consume error event
+        /// </summary>
+        IEvent<MessageErrorEventContext> MessageConsumeError { get; }
+
+        /// <summary>
+        /// Gets the message consume started event
+        /// </summary>
+        IEvent<MessageEventContext> MessageConsumeStarted { get; }
+
+        /// <summary>
+        /// Gets the message produce completed event
+        /// </summary>
+        IEvent<MessageEventContext> MessageProduceCompleted { get; }
+
+        /// <summary>
+        /// Gets the message produce error event
+        /// </summary>
+        IEvent<MessageErrorEventContext> MessageProduceError { get; }
+
+        /// <summary>
+        /// Gets the message produce started event
+        /// </summary>
+        IEvent<MessageEventContext> MessageProduceStarted { get; }
+    }
+}

--- a/src/KafkaFlow.Abstractions/Configuration/IKafkaConfigurationBuilder.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/IKafkaConfigurationBuilder.cs
@@ -21,5 +21,12 @@ namespace KafkaFlow.Configuration
         /// <returns></returns>
         IKafkaConfigurationBuilder UseLogHandler<TLogHandler>()
             where TLogHandler : ILogHandler;
+
+        /// <summary>
+        /// Subscribe the global events defined in <see cref="IGlobalEvents"/>
+        /// </summary>
+        /// <param name="observers">A handle to subscribe the events</param>
+        /// <returns></returns>
+        IKafkaConfigurationBuilder SubscribeGlobalEvents(Action<IGlobalEvents> observers);
     }
 }

--- a/src/KafkaFlow.Abstractions/IEvent.cs
+++ b/src/KafkaFlow.Abstractions/IEvent.cs
@@ -1,0 +1,32 @@
+﻿namespace KafkaFlow
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Represents an Event to be subscribed.
+    /// </summary>
+    public interface IEvent
+    {
+        /// <summary>
+        /// Subscribes to the event.
+        /// </summary>
+        /// <param name="handler">The handler to be called when the event is fired.</param>
+        /// <returns>Event subscription reference</returns>
+        IEventSubscription Subscribe(Func<Task> handler);
+    }
+
+    /// <summary>
+    /// Represents an Event to be subscribed.
+    /// </summary>
+    /// <typeparam name="TArg">The argument expected by the event.</typeparam>
+    public interface IEvent<out TArg>
+    {
+        /// <summary>
+        /// Subscribes to the event.
+        /// </summary>
+        /// <param name="handler">The handler to be called when the event is fired.</param>
+        /// <returns>Event subscription reference</returns>
+        IEventSubscription Subscribe(Func<TArg, Task> handler);
+    }
+}

--- a/src/KafkaFlow.Abstractions/IEventSubscription.cs
+++ b/src/KafkaFlow.Abstractions/IEventSubscription.cs
@@ -1,0 +1,13 @@
+﻿namespace KafkaFlow
+{
+    /// <summary>
+    /// Represents an Event subscription.
+    /// </summary>
+    public interface IEventSubscription
+    {
+        /// <summary>
+        /// Cancels the subscription to the event.
+        /// </summary>
+        void Cancel();
+    }
+}

--- a/src/KafkaFlow.Abstractions/IMessageContext.cs
+++ b/src/KafkaFlow.Abstractions/IMessageContext.cs
@@ -1,6 +1,7 @@
 namespace KafkaFlow
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// A context that contains the message and metadata
@@ -26,6 +27,11 @@ namespace KafkaFlow
         /// Gets the <see cref="IProducerContext"></see> from the produced message
         /// </summary>
         IProducerContext ProducerContext { get; }
+
+        /// <summary>
+        /// Gets the items
+        /// </summary>
+        IDictionary<string, object> Items { get; }
 
         /// <summary>
         /// Creates a new <see cref="IMessageContext"/> with the new message

--- a/src/KafkaFlow.Abstractions/MessageErrorEventContext.cs
+++ b/src/KafkaFlow.Abstractions/MessageErrorEventContext.cs
@@ -1,0 +1,26 @@
+﻿namespace KafkaFlow
+{
+    using System;
+
+    /// <summary>
+    /// Represents the errors in message context used in the events
+    /// </summary>
+    public class MessageErrorEventContext : MessageEventContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageErrorEventContext"/> class.
+        /// </summary>
+        /// <param name="messageContext">The message context</param>
+        /// <param name="exception">The event exception</param>
+        public MessageErrorEventContext(IMessageContext messageContext, Exception exception)
+            : base(messageContext)
+        {
+            this.Exception = exception;
+        }
+
+        /// <summary>
+        /// Gets the exception
+        /// </summary>
+        public Exception Exception { get; }
+    }
+}

--- a/src/KafkaFlow.Abstractions/MessageEventContext.cs
+++ b/src/KafkaFlow.Abstractions/MessageEventContext.cs
@@ -1,0 +1,22 @@
+﻿namespace KafkaFlow
+{
+    /// <summary>
+    /// Represents a message context used in the events
+    /// </summary>
+    public class MessageEventContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageEventContext"/> class.
+        /// </summary>
+        /// <param name="messageContext">The message context</param>
+        public MessageEventContext(IMessageContext messageContext)
+        {
+            this.MessageContext = messageContext;
+        }
+
+        /// <summary>
+        /// Gets the message context
+        /// </summary>
+        public IMessageContext MessageContext { get; }
+    }
+}

--- a/src/KafkaFlow.BatchConsume/BatchConsumeMessageContext.cs
+++ b/src/KafkaFlow.BatchConsume/BatchConsumeMessageContext.cs
@@ -11,6 +11,7 @@ namespace KafkaFlow.BatchConsume
         {
             this.ConsumerContext = consumer;
             this.Message = new Message(null, batchMessage);
+            this.Items = new Dictionary<string, object>();
         }
 
         public Message Message { get; }
@@ -20,6 +21,8 @@ namespace KafkaFlow.BatchConsume
         public IConsumerContext ConsumerContext { get; }
 
         public IProducerContext ProducerContext => null;
+
+        public IDictionary<string, object> Items { get; }
 
         public IMessageContext SetMessage(object key, object value) =>
             throw new NotSupportedException($"{nameof(BatchConsumeMessageContext)} does not allow change the message");

--- a/src/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
+++ b/src/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
@@ -97,8 +97,9 @@ namespace KafkaFlow.IntegrationTests.Core
             };
 
             services.AddKafka(
-                kafka => kafka
-                    .UseLogHandler<TraceLogHandler>()
+                kafka =>
+                {
+                    kafka.UseLogHandler<TraceLogHandler>()
                     .AddCluster(
                         cluster => cluster
                             .WithBrokers(kafkaBrokers.Split(';'))
@@ -332,7 +333,8 @@ namespace KafkaFlow.IntegrationTests.Core
                                     .DefaultTopic(GzipTopicName)
                                     .AddMiddlewares(
                                         middlewares => middlewares
-                                            .AddCompressor<GzipMessageCompressor>()))));
+                                            .AddCompressor<GzipMessageCompressor>())));
+                });
 
             services.AddSingleton<JsonProducer>();
             services.AddSingleton<JsonGzipProducer>();

--- a/src/KafkaFlow.IntegrationTests/Core/Exceptions/ErrorExecutingMiddlewareException.cs
+++ b/src/KafkaFlow.IntegrationTests/Core/Exceptions/ErrorExecutingMiddlewareException.cs
@@ -1,0 +1,12 @@
+﻿namespace KafkaFlow.IntegrationTests.Core.Exceptions
+{
+    using System;
+
+    public class ErrorExecutingMiddlewareException : Exception
+    {
+        public ErrorExecutingMiddlewareException(string middlewareName)
+            : base($"Exception thrown executing {middlewareName}")
+        {
+        }
+    }
+}

--- a/src/KafkaFlow.IntegrationTests/Core/Exceptions/PartitionAssignmentException.cs
+++ b/src/KafkaFlow.IntegrationTests/Core/Exceptions/PartitionAssignmentException.cs
@@ -1,0 +1,14 @@
+﻿namespace KafkaFlow.IntegrationTests.Core.Exceptions
+{
+    using System;
+
+    public class PartitionAssignmentException : Exception
+    {
+        private const string ExceptionMessage = "Partition assignment hasn't occurred yet.";
+
+        public PartitionAssignmentException()
+            : base(ExceptionMessage)
+        {
+        }
+    }
+}

--- a/src/KafkaFlow.IntegrationTests/Core/Producers/JsonProducer2.cs
+++ b/src/KafkaFlow.IntegrationTests/Core/Producers/JsonProducer2.cs
@@ -1,0 +1,6 @@
+﻿namespace KafkaFlow.IntegrationTests.Core.Producers
+{
+    internal class JsonProducer2
+    {
+    }
+}

--- a/src/KafkaFlow.IntegrationTests/GlobalEventsTest.cs
+++ b/src/KafkaFlow.IntegrationTests/GlobalEventsTest.cs
@@ -1,0 +1,320 @@
+﻿namespace KafkaFlow.IntegrationTests
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AutoFixture;
+    using Confluent.Kafka;
+    using KafkaFlow.Configuration;
+    using KafkaFlow.IntegrationTests.Core;
+    using KafkaFlow.IntegrationTests.Core.Exceptions;
+    using KafkaFlow.IntegrationTests.Core.Handlers;
+    using KafkaFlow.IntegrationTests.Core.Messages;
+    using KafkaFlow.IntegrationTests.Core.Middlewares;
+    using KafkaFlow.IntegrationTests.Core.Producers;
+    using KafkaFlow.Serializer;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Polly;
+
+    [TestClass]
+    public class GlobalEventsTest
+    {
+        private readonly Fixture fixture = new();
+        private string topic;
+        private bool isPartitionAssigned;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.topic = $"GlobalEventsTestTopic_{Guid.NewGuid()}";
+
+            MessageStorage.Clear();
+        }
+
+        [TestMethod]
+        public async Task SubscribeGlobalEvents_AllEvents_TriggeredCorrectly()
+        {
+            // Arrange
+            bool isMessageProducedStarted = false, isMessageConsumeStarted = false, isMessageConsumeCompleted = false;
+
+            void ConfigureGlobalEvents(IGlobalEvents observers)
+            {
+                observers.MessageProduceStarted.Subscribe(eventContext =>
+                {
+                    isMessageProducedStarted = true;
+                    return Task.CompletedTask;
+                });
+
+                observers.MessageConsumeStarted.Subscribe(eventContext =>
+                {
+                    isMessageConsumeStarted = true;
+                    return Task.CompletedTask;
+                });
+
+                observers.MessageConsumeCompleted.Subscribe(eventContext =>
+                {
+                    isMessageConsumeCompleted = true;
+                    return Task.CompletedTask;
+                });
+            }
+
+            var provider = await this.GetServiceProviderAsync(
+                ConfigureGlobalEvents,
+                this.ConfigureConsumer<GzipMiddleware>,
+                this.ConfigureProducer<ProtobufNetSerializer>);
+            MessageStorage.Clear();
+
+            var producer = provider.GetRequiredService<IMessageProducer<JsonProducer2>>();
+            var message = this.fixture.Create<byte[]>();
+
+            // Act
+            await producer.ProduceAsync(null, message);
+
+            await MessageStorage.AssertMessageAsync(message);
+
+            // Assert
+            Assert.IsTrue(isMessageProducedStarted);
+            Assert.IsTrue(isMessageConsumeStarted);
+            Assert.IsTrue(isMessageConsumeCompleted);
+        }
+
+        [TestMethod]
+        public async Task SubscribeGlobalEvents_MessageContext_IsAssignedCorrectly()
+        {
+            // Arrange
+            IMessageContext messageContext = null;
+
+            void ConfigureGlobalEvents(IGlobalEvents observers)
+            {
+                observers.MessageProduceStarted.Subscribe(eventContext =>
+                {
+                    messageContext = eventContext.MessageContext;
+                    return Task.CompletedTask;
+                });
+            }
+
+            var provider = await this.GetServiceProviderAsync(
+                ConfigureGlobalEvents,
+                this.ConfigureConsumer<GzipMiddleware>,
+                this.ConfigureProducer<ProtobufNetSerializer>);
+
+            MessageStorage.Clear();
+
+            var producer = provider.GetRequiredService<IMessageProducer<JsonProducer2>>();
+            var message = this.fixture.Create<TestMessage1>();
+
+            // Act
+            producer.Produce(message.Id.ToString(), message);
+
+            // Assert
+            Assert.IsNotNull(messageContext);
+            Assert.AreEqual(messageContext.Message.Key, message.Id.ToString());
+        }
+
+        [TestMethod]
+        public async Task SubscribeGlobalEvents_ConsumerErrorEvent_TriggeredCorrectly()
+        {
+            // Arrange
+            bool isMessageProducedStarted = false, isMessageConsumeStarted = false, isMessageConsumerError = false;
+
+            void ConfigureGlobalEvents(IGlobalEvents observers)
+            {
+                observers.MessageProduceStarted.Subscribe(eventContext =>
+                {
+                    isMessageProducedStarted = true;
+                    return Task.CompletedTask;
+                });
+
+                observers.MessageConsumeStarted.Subscribe(eventContext =>
+                {
+                    isMessageConsumeStarted = true;
+                    return Task.CompletedTask;
+                });
+
+                observers.MessageConsumeError.Subscribe(eventContext =>
+                {
+                    isMessageConsumerError = true;
+                    return Task.CompletedTask;
+                });
+            }
+
+            var provider = await this.GetServiceProviderAsync(
+                ConfigureGlobalEvents,
+                this.ConfigureConsumer<TriggerErrorMessageMiddleware>,
+                this.ConfigureProducer<ProtobufNetSerializer>);
+
+            MessageStorage.Clear();
+
+            var producer = provider.GetRequiredService<IMessageProducer<JsonProducer2>>();
+            var message = this.fixture.Create<byte[]>();
+
+            // Act
+            await producer.ProduceAsync(null, message);
+
+            await MessageStorage.AssertMessageAsync(message);
+
+            // Assert
+            Assert.IsTrue(isMessageProducedStarted);
+            Assert.IsTrue(isMessageConsumeStarted);
+            Assert.IsTrue(isMessageConsumerError);
+        }
+
+        [TestMethod]
+        public async Task SubscribeGlobalEvents_ProducerErrorEvent_TriggeredCorrectly()
+        {
+            // Arrange
+            bool isMessageProducedStarted = false, isProduceErrorFired = false;
+
+            void ConfigureGlobalEvents(IGlobalEvents observers)
+            {
+                observers.MessageProduceStarted.Subscribe(eventContext =>
+                {
+                    isMessageProducedStarted = true;
+                    return Task.CompletedTask;
+                });
+
+                observers.MessageProduceError.Subscribe(eventContext =>
+                {
+                    isProduceErrorFired = true;
+                    return Task.CompletedTask;
+                });
+            }
+
+            var provider = await this.GetServiceProviderAsync(
+                ConfigureGlobalEvents,
+                this.ConfigureConsumer<TriggerErrorMessageMiddleware>,
+                this.ConfigureProducer<TriggerErrorSerializerMiddleware>);
+
+            MessageStorage.Clear();
+            var producer = provider.GetRequiredService<IMessageProducer<JsonProducer2>>();
+            var message = this.fixture.Create<byte[]>();
+            var errorOccured = false;
+
+            // Act
+            try
+            {
+                await producer.ProduceAsync(null, message);
+            }
+            catch (ProduceException<byte[], byte[]> ex)
+            {
+                // Assert
+                errorOccured = true;
+                Assert.IsTrue(ex.GetType() == typeof(ProduceException<byte[], byte[]>));
+                Assert.IsTrue(isMessageProducedStarted);
+                Assert.IsTrue(isProduceErrorFired);
+            }
+
+            Assert.IsTrue(errorOccured);
+        }
+
+        private void ConfigureConsumer<T>(IConsumerConfigurationBuilder consumerConfigurationBuilder)
+            where T : class, IMessageMiddleware
+        {
+            consumerConfigurationBuilder
+                .Topic(this.topic)
+                .WithGroupId(this.topic)
+                .WithBufferSize(100)
+                .WithWorkersCount(10)
+                .WithAutoOffsetReset(KafkaFlow.AutoOffsetReset.Earliest)
+                .AddMiddlewares(
+                    middlewares => middlewares
+                        .AddSerializer<ProtobufNetSerializer>()
+                        .Add<T>())
+                .WithPartitionsAssignedHandler((_, _) =>
+                {
+                    this.isPartitionAssigned = true;
+                });
+        }
+
+        private void ConfigureProducer<T>(IProducerConfigurationBuilder producerConfigurationBuilder)
+            where T : class, ISerializer
+        {
+            producerConfigurationBuilder
+                .DefaultTopic(this.topic)
+                .AddMiddlewares(middlewares => middlewares.AddSerializer<T>());
+        }
+
+        private async Task<IServiceProvider> GetServiceProviderAsync(
+            Action<IGlobalEvents> configureGlobalEvents,
+            Action<IConsumerConfigurationBuilder> consumerConfiguration,
+            Action<IProducerConfigurationBuilder> producerConfiguration)
+        {
+            this.isPartitionAssigned = false;
+
+            var builder = Host
+                .CreateDefaultBuilder()
+                .ConfigureAppConfiguration(
+                    (_, config) =>
+                    {
+                        config
+                            .SetBasePath(Directory.GetCurrentDirectory())
+                            .AddJsonFile(
+                                "conf/appsettings.json",
+                                false,
+                                true)
+                            .AddEnvironmentVariables();
+                    })
+                .ConfigureServices((context, services) =>
+                    services.AddKafka(
+                        kafka => kafka
+                            .UseLogHandler<TraceLogHandler>()
+                            .AddCluster(
+                                cluster => cluster
+                                    .WithBrokers(context.Configuration.GetValue<string>("Kafka:Brokers").Split(';'))
+                                    .CreateTopicIfNotExists(this.topic, 1, 1)
+                                    .AddProducer<JsonProducer2>(producerConfiguration)
+                                    .AddConsumer(consumerConfiguration))
+                            .SubscribeGlobalEvents(configureGlobalEvents)))
+                .UseDefaultServiceProvider(
+                    (_, options) =>
+                    {
+                        options.ValidateScopes = true;
+                        options.ValidateOnBuild = true;
+                    });
+
+            var host = builder.Build();
+            var bus = host.Services.CreateKafkaBus();
+            bus.StartAsync().GetAwaiter().GetResult();
+
+            await this.WaitForPartitionAssignmentAsync();
+
+            return host.Services;
+        }
+
+        private async Task WaitForPartitionAssignmentAsync()
+        {
+            await Policy
+                .HandleResult<bool>(isAvailable => !isAvailable)
+                .WaitAndRetryAsync(Enumerable.Range(0, 6).Select(i => TimeSpan.FromSeconds(Math.Pow(i, 2))))
+                .ExecuteAsync(() => Task.FromResult(this.isPartitionAssigned));
+        }
+
+        private class TriggerErrorMessageMiddleware : IMessageMiddleware
+        {
+            public async Task Invoke(IMessageContext context, MiddlewareDelegate _)
+            {
+                MessageStorage.Add((byte[])context.Message.Value);
+                throw new ErrorExecutingMiddlewareException(nameof(TriggerErrorMessageMiddleware));
+            }
+        }
+
+        private class TriggerErrorSerializerMiddleware : ISerializer
+        {
+            public Task SerializeAsync(object _, Stream output, ISerializerContext context)
+            {
+                var error = new Error(ErrorCode.BrokerNotAvailable);
+                throw new ProduceException<byte[], byte[]>(error, null);
+            }
+
+            public Task<object> DeserializeAsync(Stream _, Type type, ISerializerContext context)
+            {
+                var error = new Error(ErrorCode.BrokerNotAvailable);
+                throw new ProduceException<byte[], byte[]>(error,null);
+            }
+        }
+    }
+}

--- a/src/KafkaFlow.IntegrationTests/KafkaFlow.IntegrationTests.csproj
+++ b/src/KafkaFlow.IntegrationTests/KafkaFlow.IntegrationTests.csproj
@@ -25,6 +25,8 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.6.0" />
+		<PackageReference Include="Polly" Version="8.0.0" />
     </ItemGroup>
     
     <ItemGroup Condition="$([MSBuild]::IsOsPlatform('OSX'))">
@@ -37,6 +39,7 @@
         <ProjectReference Include="..\KafkaFlow.Compressor.Gzip\KafkaFlow.Compressor.Gzip.csproj" />
         <ProjectReference Include="..\KafkaFlow.Compressor\KafkaFlow.Compressor.csproj" />
         <ProjectReference Include="..\KafkaFlow.Microsoft.DependencyInjection\KafkaFlow.Microsoft.DependencyInjection.csproj" />
+        <ProjectReference Include="..\KafkaFlow.OpenTelemetry\KafkaFlow.OpenTelemetry.csproj" />
         <ProjectReference Include="..\KafkaFlow.Serializer.JsonCore\KafkaFlow.Serializer.JsonCore.csproj" />
         <ProjectReference Include="..\KafkaFlow.Serializer.ProtobufNet\KafkaFlow.Serializer.ProtobufNet.csproj" />
         <ProjectReference Include="..\KafkaFlow.Serializer.SchemaRegistry.ConfluentAvro\KafkaFlow.Serializer.SchemaRegistry.ConfluentAvro.csproj" />

--- a/src/KafkaFlow.IntegrationTests/OpenTelemetryTests.cs
+++ b/src/KafkaFlow.IntegrationTests/OpenTelemetryTests.cs
@@ -1,0 +1,202 @@
+﻿namespace KafkaFlow.IntegrationTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AutoFixture;
+    using global::OpenTelemetry;
+    using global::OpenTelemetry.Trace;
+    using KafkaFlow.Compressor;
+    using KafkaFlow.Compressor.Gzip;
+    using KafkaFlow.Configuration;
+    using KafkaFlow.IntegrationTests.Core;
+    using KafkaFlow.IntegrationTests.Core.Handlers;
+    using KafkaFlow.IntegrationTests.Core.Middlewares;
+    using KafkaFlow.IntegrationTests.Core.Producers;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Polly;
+
+    [TestClass]
+    public class OpenTelemetryTests
+    {
+        private readonly Fixture fixture = new();
+
+        private List<Activity> exportedItems;
+
+        private bool isPartitionAssigned;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.exportedItems = new List<Activity>();
+        }
+
+        [TestMethod]
+        public async Task AddOpenTelemetry_ProducingAndConsumingOneMessage_TraceAndSpansAreCreatedCorrectly()
+        {
+            // Arrange
+            var provider = await this.GetServiceProvider();
+            MessageStorage.Clear();
+
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("KafkaFlow.OpenTelemetry")
+            .AddInMemoryExporter(this.exportedItems)
+            .Build();
+
+            var producer = provider.GetRequiredService<IMessageProducer<GzipProducer>>();
+            var message = this.fixture.Create<byte[]>();
+
+            // Act
+            await producer.ProduceAsync(null, message);
+
+            // Assert
+            var (producerSpan, consumerSpan) = await this.WaitForSpansAsync();
+
+            Assert.IsNotNull(this.exportedItems);
+            Assert.IsNull(producerSpan.ParentId);
+            Assert.AreEqual(producerSpan.TraceId, consumerSpan.TraceId);
+            Assert.AreEqual(consumerSpan.ParentSpanId, producerSpan.SpanId);
+        }
+
+        [TestMethod]
+        public async Task AddOpenTelemetry_ProducingAndConsumingOneMessage_BaggageIsPropagatedFromTestActivityToConsumer()
+        {
+            // Arrange
+            var provider = await this.GetServiceProvider();
+            MessageStorage.Clear();
+
+            var kafkaFlowTestString = "KafkaFlowTest";
+            var baggageName1 = "TestBaggage1";
+            var baggageValue1 = "TestBaggageValue1";
+            var baggageName2 = "TestBaggage2";
+            var baggageValue2 = "TestBaggageValue2";
+
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("KafkaFlow.OpenTelemetry")
+            .AddSource(kafkaFlowTestString)
+            .AddInMemoryExporter(this.exportedItems)
+            .Build();
+
+            var producer = provider.GetRequiredService<IMessageProducer<GzipProducer>>();
+            var message = this.fixture.Create<byte[]>();
+
+            // Act
+            ActivitySource activitySource = new(kafkaFlowTestString);
+
+            var activity = activitySource.StartActivity("TestActivity", ActivityKind.Client);
+
+            activity.AddBaggage(baggageName1, baggageValue1);
+            activity.AddBaggage(baggageName2, baggageValue2);
+
+            await producer.ProduceAsync(null, message);
+
+            // Assert
+            var (producerSpan, consumerSpan) = await this.WaitForSpansAsync();
+
+            Assert.IsNotNull(this.exportedItems);
+            Assert.AreEqual(producerSpan.TraceId, consumerSpan.TraceId);
+            Assert.AreEqual(consumerSpan.ParentSpanId, producerSpan.SpanId);
+            Assert.AreEqual(producerSpan.GetBaggageItem(baggageName1), baggageValue1);
+            Assert.AreEqual(consumerSpan.GetBaggageItem(baggageName1), baggageValue1);
+            Assert.AreEqual(producerSpan.GetBaggageItem(baggageName2), baggageValue2);
+            Assert.AreEqual(consumerSpan.GetBaggageItem(baggageName2), baggageValue2);
+        }
+
+        private async Task<IServiceProvider> GetServiceProvider()
+        {
+            var topicName = $"OpenTelemetryTestTopic_{Guid.NewGuid()}";
+
+            this.isPartitionAssigned = false;
+
+            var builder = Host
+                .CreateDefaultBuilder()
+                .ConfigureAppConfiguration(
+                    (_, config) =>
+                    {
+                        config
+                            .SetBasePath(Directory.GetCurrentDirectory())
+                            .AddJsonFile(
+                                "conf/appsettings.json",
+                                false,
+                                true)
+                            .AddEnvironmentVariables();
+                    })
+                .ConfigureServices((context, services) =>
+                    services.AddKafka(
+                        kafka => kafka
+                            .UseLogHandler<TraceLogHandler>()
+                            .AddCluster(
+                                cluster => cluster
+                                    .WithBrokers(context.Configuration.GetValue<string>("Kafka:Brokers").Split(';'))
+                                    .CreateTopicIfNotExists(topicName, 1, 1)
+                                    .AddProducer<GzipProducer>(
+                                        producer => producer
+                                            .DefaultTopic(topicName)
+                                            .AddMiddlewares(
+                                                middlewares => middlewares
+                                                    .AddCompressor<GzipMessageCompressor>()))
+                                    .AddConsumer(
+                                        consumer => consumer
+                                            .Topic(topicName)
+                                            .WithGroupId(topicName)
+                                            .WithBufferSize(100)
+                                            .WithWorkersCount(10)
+                                            .WithAutoOffsetReset(AutoOffsetReset.Latest)
+                                            .AddMiddlewares(
+                                                middlewares => middlewares
+                                                    .AddCompressor<GzipMessageCompressor>()
+                                                    .Add<GzipMiddleware>())
+                                            .WithPartitionsAssignedHandler((_, _) =>
+                                            {
+                                                this.isPartitionAssigned = true;
+                                            })))
+                            .AddOpenTelemetryInstrumentation()))
+                .UseDefaultServiceProvider(
+                    (_, options) =>
+                    {
+                        options.ValidateScopes = true;
+                        options.ValidateOnBuild = true;
+                    });
+
+            var host = builder.Build();
+            var bus = host.Services.CreateKafkaBus();
+            bus.StartAsync().GetAwaiter().GetResult();
+
+            await this.WaitForPartitionAssignmentAsync();
+
+            return host.Services;
+        }
+
+        private async Task WaitForPartitionAssignmentAsync()
+        {
+            await Policy
+                .HandleResult<bool>(isAvailable => !isAvailable)
+                .WaitAndRetryAsync(Enumerable.Range(0, 6).Select(i => TimeSpan.FromSeconds(Math.Pow(i, 2))))
+                .ExecuteAsync(() => Task.FromResult(this.isPartitionAssigned));
+        }
+
+        private async Task<(Activity producerSpan, Activity consumerSpan)> WaitForSpansAsync()
+        {
+            Activity producerSpan = null, consumerSpan = null;
+
+            await Policy
+                .HandleResult<bool>(isAvailable => !isAvailable)
+                .WaitAndRetryAsync(Enumerable.Range(0, 6).Select(i => TimeSpan.FromSeconds(Math.Pow(i, 2))))
+                .ExecuteAsync(() =>
+                {
+                    producerSpan = this.exportedItems.Find(x => x.Kind == ActivityKind.Producer);
+                    consumerSpan = this.exportedItems.Find(x => x.Kind == ActivityKind.Consumer);
+
+                    return Task.FromResult(producerSpan != null && consumerSpan != null);
+                });
+
+            return (producerSpan, consumerSpan);
+        }
+    }
+}

--- a/src/KafkaFlow.OpenTelemetry/ActivitySourceAccessor.cs
+++ b/src/KafkaFlow.OpenTelemetry/ActivitySourceAccessor.cs
@@ -1,0 +1,41 @@
+﻿extern alias SemanticConventions;
+
+namespace KafkaFlow.OpenTelemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Reflection;
+    using Conventions = SemanticConventions::OpenTelemetry.Trace.TraceSemanticConventions;
+
+    internal static class ActivitySourceAccessor
+    {
+        internal const string ActivityString = "otel_activity";
+        internal const string ExceptionEventKey = "exception";
+        internal const string MessagingSystemId = "kafka";
+        internal const string AttributeMessagingOperation = "messaging.operation";
+        internal const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
+        internal const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
+        internal static readonly AssemblyName AssemblyName = typeof(ActivitySourceAccessor).Assembly.GetName();
+        internal static readonly string ActivitySourceName = AssemblyName.Name;
+        internal static readonly string Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version);
+
+        public static void SetGenericTags(Activity activity)
+        {
+            activity?.SetTag(Conventions.AttributeMessagingSystem, MessagingSystemId);
+        }
+
+        public static ActivityEvent CreateExceptionEvent(Exception exception)
+        {
+            var activityTagCollection = new ActivityTagsCollection(
+                new[]
+                {
+                    new KeyValuePair<string, object>(Conventions.AttributeExceptionMessage, exception.Message),
+                    new KeyValuePair<string, object>(Conventions.AttributeExceptionStacktrace, exception.StackTrace),
+                });
+
+            return new ActivityEvent(ExceptionEventKey, DateTimeOffset.UtcNow, activityTagCollection);
+        }
+    }
+}

--- a/src/KafkaFlow.OpenTelemetry/ExtensionMethods.cs
+++ b/src/KafkaFlow.OpenTelemetry/ExtensionMethods.cs
@@ -1,0 +1,35 @@
+﻿namespace KafkaFlow.Configuration
+{
+    using KafkaFlow.OpenTelemetry;
+
+    /// <summary>
+    /// Adds OpenTelemetry instrumentation
+    /// </summary>
+    public static class ExtensionMethods
+    {
+        /// <summary>
+        /// Adds OpenTelemetry instrumentation
+        /// </summary>
+        /// <param name="builder">The Kafka configuration builder</param>
+        /// <returns></returns>
+        public static IKafkaConfigurationBuilder AddOpenTelemetryInstrumentation(this IKafkaConfigurationBuilder builder)
+        {
+            builder.SubscribeGlobalEvents(hub =>
+            {
+                hub.MessageConsumeStarted.Subscribe(eventContext => OpenTelemetryConsumerEventsHandler.OnConsumeStarted(eventContext.MessageContext));
+
+                hub.MessageConsumeError.Subscribe(eventContext => OpenTelemetryConsumerEventsHandler.OnConsumeError(eventContext.MessageContext, eventContext.Exception));
+
+                hub.MessageConsumeCompleted.Subscribe(eventContext => OpenTelemetryConsumerEventsHandler.OnConsumeCompleted(eventContext.MessageContext));
+
+                hub.MessageProduceStarted.Subscribe(eventContext => OpenTelemetryProducerEventsHandler.OnProducerStarted(eventContext.MessageContext));
+
+                hub.MessageProduceError.Subscribe(eventContext => OpenTelemetryProducerEventsHandler.OnProducerError(eventContext.MessageContext, eventContext.Exception));
+
+                hub.MessageProduceCompleted.Subscribe(eventContext => OpenTelemetryProducerEventsHandler.OnProducerCompleted(eventContext.MessageContext));
+            });
+
+            return builder;
+        }
+    }
+}

--- a/src/KafkaFlow.OpenTelemetry/KafkaFlow.OpenTelemetry.csproj
+++ b/src/KafkaFlow.OpenTelemetry/KafkaFlow.OpenTelemetry.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.SemanticConventions" Version="1.0.0-rc9.9">
+      <Aliases>SemanticConventions</Aliases>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KafkaFlow.Abstractions\KafkaFlow.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/KafkaFlow.OpenTelemetry/OpenTelemetryConsumerEventsHandler.cs
+++ b/src/KafkaFlow.OpenTelemetry/OpenTelemetryConsumerEventsHandler.cs
@@ -1,0 +1,97 @@
+﻿namespace KafkaFlow.OpenTelemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using System.Threading.Tasks;
+    using global::OpenTelemetry;
+    using global::OpenTelemetry.Context.Propagation;
+
+    internal static class OpenTelemetryConsumerEventsHandler
+    {
+        private const string ProcessString = "process";
+        private const string AttributeMessagingSourceName = "messaging.source.name";
+        private const string AttributeMessagingKafkaConsumerGroup = "messaging.kafka.consumer.group";
+        private const string AttributeMessagingKafkaSourcePartition = "messaging.kafka.source.partition";
+        private static readonly TextMapPropagator Propagator = Propagators.DefaultTextMapPropagator;
+
+        public static Task OnConsumeStarted(IMessageContext context)
+        {
+            try
+            {
+                var activityName = !string.IsNullOrEmpty(context?.ConsumerContext.Topic) ? $"{context?.ConsumerContext.Topic} {ProcessString}" : ProcessString;
+
+                // Extract the PropagationContext of the upstream parent from the message headers.
+                var parentContext = Propagator.Extract(new PropagationContext(default, Baggage.Current), context, ExtractTraceContextIntoBasicProperties);
+                Baggage.Current = parentContext.Baggage;
+
+                // Start an activity with a name following the semantic convention of the OpenTelemetry messaging specification.
+                // The convention also defines a set of attributes (in .NET they are mapped as `tags`) to be populated in the activity.
+                // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md
+                var activity = ActivitySourceAccessor.ActivitySource.StartActivity(activityName, ActivityKind.Consumer, parentContext.ActivityContext);
+
+                foreach (var item in Baggage.Current)
+                {
+                    activity?.AddBaggage(item.Key, item.Value);
+                }
+
+                context?.Items.Add(ActivitySourceAccessor.ActivityString, activity);
+
+                ActivitySourceAccessor.SetGenericTags(activity);
+
+                if (activity != null && activity.IsAllDataRequested)
+                {
+                    SetConsumerTags(context, activity);
+                }
+            }
+            catch
+            {
+                // If there is any failure, do not propagate the context.
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public static Task OnConsumeCompleted(IMessageContext context)
+        {
+            if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
+            {
+                activity?.Dispose();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public static Task OnConsumeError(IMessageContext context, Exception ex)
+        {
+            if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
+            {
+                var exceptionEvent = ActivitySourceAccessor.CreateExceptionEvent(ex);
+
+                activity?.AddEvent(exceptionEvent);
+
+                activity?.Dispose();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static IEnumerable<string> ExtractTraceContextIntoBasicProperties(IMessageContext context, string key)
+        {
+            return new[] { context.Headers.GetString(key, Encoding.UTF8) };
+        }
+
+        private static void SetConsumerTags(IMessageContext context, Activity activity)
+        {
+            var messageKey = Encoding.UTF8.GetString(context.Message.Key as byte[]);
+
+            activity.SetTag(ActivitySourceAccessor.AttributeMessagingOperation, ProcessString);
+            activity.SetTag(AttributeMessagingSourceName, context.ConsumerContext.Topic);
+            activity.SetTag(AttributeMessagingKafkaConsumerGroup, context.ConsumerContext.GroupId);
+            activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageKey, messageKey);
+            activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageOffset, context.ConsumerContext.Offset);
+            activity.SetTag(AttributeMessagingKafkaSourcePartition, context.ConsumerContext.Partition);
+        }
+    }
+}

--- a/src/KafkaFlow.OpenTelemetry/OpenTelemetryProducerEventsHandler.cs
+++ b/src/KafkaFlow.OpenTelemetry/OpenTelemetryProducerEventsHandler.cs
@@ -1,0 +1,107 @@
+﻿namespace KafkaFlow.OpenTelemetry
+{
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using global::OpenTelemetry;
+    using global::OpenTelemetry.Context.Propagation;
+
+    internal static class OpenTelemetryProducerEventsHandler
+    {
+        private const string PublishString = "publish";
+        private const string AttributeMessagingDestinationName = "messaging.destination.name";
+        private const string AttributeMessagingKafkaDestinationPartition = "messaging.kafka.destination.partition";
+        private static readonly TextMapPropagator Propagator = Propagators.DefaultTextMapPropagator;
+
+        public static Task OnProducerStarted(IMessageContext context)
+        {
+            try
+            {
+                var activityName = !string.IsNullOrEmpty(context?.ProducerContext.Topic) ? $"{context?.ProducerContext.Topic} {PublishString}" : PublishString;
+
+                // Start an activity with a name following the semantic convention of the OpenTelemetry messaging specification.
+                // The convention also defines a set of attributes (in .NET they are mapped as `tags`) to be populated in the activity.
+                // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md
+                var activity = ActivitySourceAccessor.ActivitySource.StartActivity(activityName, ActivityKind.Producer);
+
+                // Depending on Sampling (and whether a listener is registered or not), the
+                // activity above may not be created.
+                // If it is created, then propagate its context.
+                // If it is not created, the propagate the Current context, if any.
+                ActivityContext contextToInject = default;
+
+                if (activity != null)
+                {
+                    context?.Items.Add(ActivitySourceAccessor.ActivityString, activity);
+
+                    contextToInject = activity.Context;
+                }
+                else if (Activity.Current != null)
+                {
+                    contextToInject = Activity.Current.Context;
+                }
+
+                Baggage.Current = Baggage.Create(activity?.Baggage.ToDictionary(item => item.Key, item => item.Value));
+
+                // Inject the ActivityContext into the message headers to propagate trace context to the receiving service.
+                Propagator.Inject(new PropagationContext(contextToInject, Baggage.Current), context, InjectTraceContextIntoBasicProperties);
+
+                ActivitySourceAccessor.SetGenericTags(activity);
+
+                if (activity != null && activity.IsAllDataRequested)
+                {
+                    SetProducerTags(context, activity);
+                }
+            }
+            catch
+            {
+                // If there is any failure, do not propagate the context.
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public static Task OnProducerCompleted(IMessageContext context)
+        {
+            if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
+            {
+                activity?.Dispose();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public static Task OnProducerError(IMessageContext context, Exception ex)
+        {
+            if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
+            {
+                var exceptionEvent = ActivitySourceAccessor.CreateExceptionEvent(ex);
+
+                activity?.AddEvent(exceptionEvent);
+
+                activity?.Dispose();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static void InjectTraceContextIntoBasicProperties(IMessageContext context, string key, string value)
+        {
+            if (!context.Headers.Any(x => x.Key == key))
+            {
+                context.Headers.SetString(key, value, Encoding.ASCII);
+            }
+        }
+
+        private static void SetProducerTags(IMessageContext context, Activity activity)
+        {
+            activity.SetTag(ActivitySourceAccessor.AttributeMessagingOperation, PublishString);
+            activity.SetTag(AttributeMessagingDestinationName, context?.ProducerContext.Topic);
+            activity.SetTag(AttributeMessagingKafkaDestinationPartition, context?.ProducerContext.Partition);
+            activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageKey, context?.Message.Key);
+            activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageOffset, context?.ProducerContext.Offset);
+        }
+    }
+}

--- a/src/KafkaFlow.sln
+++ b/src/KafkaFlow.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29709.97
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34031.279
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow", "KafkaFlow\KafkaFlow.csproj", "{E1055352-9F5B-4980-80A3-50C335B79A16}"
 EndProject
@@ -73,11 +73,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Serializer.Schema
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Admin.Dashboard", "KafkaFlow.Admin.Dashboard\KafkaFlow.Admin.Dashboard.csproj", "{4072F646-9393-4BF3-A479-0550AC1BB6C4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.Dashboard", "..\samples\KafkaFlow.Sample.Dashboard\KafkaFlow.Sample.Dashboard.csproj", "{F32DC7DA-36EA-4199-91F5-81960FD9C650}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Sample.Dashboard", "..\samples\KafkaFlow.Sample.Dashboard\KafkaFlow.Sample.Dashboard.csproj", "{F32DC7DA-36EA-4199-91F5-81960FD9C650}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.SchemaRegistry", "..\samples\KafkaFlow.Sample.SchemaRegistry\KafkaFlow.Sample.SchemaRegistry.csproj", "{2BD49C06-7A88-4B98-91B0-659282D2A45E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Sample.SchemaRegistry", "..\samples\KafkaFlow.Sample.SchemaRegistry\KafkaFlow.Sample.SchemaRegistry.csproj", "{2BD49C06-7A88-4B98-91B0-659282D2A45E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.FlowControl", "..\samples\KafkaFlow.Sample.FlowControl\KafkaFlow.Sample.FlowControl.csproj", "{7B61C99E-3AEB-4497-8A38-F780CB309130}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Sample.FlowControl", "..\samples\KafkaFlow.Sample.FlowControl\KafkaFlow.Sample.FlowControl.csproj", "{7B61C99E-3AEB-4497-8A38-F780CB309130}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{4A6A390C-A63A-4371-86BB-28481AD6D4C0}"
 	ProjectSection(SolutionItems) = preProject
@@ -85,11 +85,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{4A6A39
 		..\.github\workflows\publish.yml = ..\.github\workflows\publish.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.LogHandler.Microsoft", "KafkaFlow.LogHandler.Microsoft\KafkaFlow.LogHandler.Microsoft.csproj", "{8EAF0D96-F760-4FEF-9237-92779F66482D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.LogHandler.Microsoft", "KafkaFlow.LogHandler.Microsoft\KafkaFlow.LogHandler.Microsoft.csproj", "{8EAF0D96-F760-4FEF-9237-92779F66482D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.PauseConsumerOnError", "..\samples\KafkaFlow.Sample.PauseConsumerOnError\KafkaFlow.Sample.PauseConsumerOnError.csproj", "{B4A9E7CE-7A37-411E-967E-D9B5FD1A3992}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Sample.PauseConsumerOnError", "..\samples\KafkaFlow.Sample.PauseConsumerOnError\KafkaFlow.Sample.PauseConsumerOnError.csproj", "{B4A9E7CE-7A37-411E-967E-D9B5FD1A3992}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.ConsumerThrottling", "..\samples\KafkaFlow.Sample.ConsumerThrottling\KafkaFlow.Sample.ConsumerThrottling.csproj", "{4A16F519-FAF8-432C-AD0A-CC44F7BD392D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.Sample.ConsumerThrottling", "..\samples\KafkaFlow.Sample.ConsumerThrottling\KafkaFlow.Sample.ConsumerThrottling.csproj", "{4A16F519-FAF8-432C-AD0A-CC44F7BD392D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Telemetry", "Telemetry", "{96F5D441-B8DE-4ABC-BEF2-F758D1B2BA39}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.OpenTelemetry", "KafkaFlow.OpenTelemetry\KafkaFlow.OpenTelemetry.csproj", "{1557B135-4925-4FA2-80DA-8AD13155F3BD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -225,6 +229,10 @@ Global
 		{4A16F519-FAF8-432C-AD0A-CC44F7BD392D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4A16F519-FAF8-432C-AD0A-CC44F7BD392D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4A16F519-FAF8-432C-AD0A-CC44F7BD392D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1557B135-4925-4FA2-80DA-8AD13155F3BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1557B135-4925-4FA2-80DA-8AD13155F3BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1557B135-4925-4FA2-80DA-8AD13155F3BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1557B135-4925-4FA2-80DA-8AD13155F3BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -264,6 +272,7 @@ Global
 		{8EAF0D96-F760-4FEF-9237-92779F66482D} = {EF626895-FDAE-4B28-9110-BA85671CBBF2}
 		{B4A9E7CE-7A37-411E-967E-D9B5FD1A3992} = {303AE78F-6C96-4DF4-AC89-5C4FD53AFF0B}
 		{4A16F519-FAF8-432C-AD0A-CC44F7BD392D} = {303AE78F-6C96-4DF4-AC89-5C4FD53AFF0B}
+		{1557B135-4925-4FA2-80DA-8AD13155F3BD} = {96F5D441-B8DE-4ABC-BEF2-F758D1B2BA39}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6AE955B5-16B0-41CF-9F12-66D15B3DD1AB}

--- a/src/KafkaFlow/Event.cs
+++ b/src/KafkaFlow/Event.cs
@@ -1,0 +1,62 @@
+﻿namespace KafkaFlow
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    internal class Event<TArg> : IEvent<TArg>
+    {
+        private readonly ILogHandler logHandler;
+
+        private readonly List<Func<TArg, Task>> handlers = new();
+
+        public Event(ILogHandler logHandler)
+        {
+            this.logHandler = logHandler;
+        }
+
+        public IEventSubscription Subscribe(Func<TArg, Task> handler)
+        {
+            if (!this.handlers.Contains(handler))
+            {
+                this.handlers.Add(handler);
+            }
+
+            return new EventSubscription(() => this.handlers.Remove(handler));
+        }
+
+        internal async Task FireAsync(TArg arg)
+        {
+            foreach (var handler in this.handlers)
+            {
+                try
+                {
+                    if (handler is null)
+                    {
+                        continue;
+                    }
+
+                    await handler.Invoke(arg);
+                }
+                catch (Exception e)
+                {
+                    this.logHandler.Error("Error firing event", e, new { Event = this.GetType().Name });
+                }
+            }
+        }
+    }
+
+    internal class Event : IEvent
+    {
+        private readonly Event<object> evt;
+
+        public Event(ILogHandler logHandler)
+        {
+            this.evt = new Event<object>(logHandler);
+        }
+
+        public IEventSubscription Subscribe(Func<Task> handler) => this.evt.Subscribe(_ => handler.Invoke());
+
+        internal Task FireAsync() => this.evt.FireAsync(null);
+    }
+}

--- a/src/KafkaFlow/EventSubscription.cs
+++ b/src/KafkaFlow/EventSubscription.cs
@@ -1,0 +1,19 @@
+﻿namespace KafkaFlow
+{
+    using System;
+
+    internal class EventSubscription : IEventSubscription
+    {
+        private readonly Action cancelDelegate;
+
+        public EventSubscription(Action cancelDelegate)
+        {
+            this.cancelDelegate = cancelDelegate;
+        }
+
+        public void Cancel()
+        {
+            this.cancelDelegate.Invoke();
+        }
+    }
+}

--- a/src/KafkaFlow/GlobalEvents.cs
+++ b/src/KafkaFlow/GlobalEvents.cs
@@ -1,0 +1,56 @@
+﻿namespace KafkaFlow
+{
+    using System.Threading.Tasks;
+    using KafkaFlow.Configuration;
+
+    internal class GlobalEvents : IGlobalEvents
+    {
+        private readonly Event<MessageEventContext> messageConsumeCompleted;
+        private readonly Event<MessageErrorEventContext> messageConsumeError;
+        private readonly Event<MessageEventContext> messageConsumeStarted;
+        private readonly Event<MessageEventContext> messageProduceCompleted;
+        private readonly Event<MessageErrorEventContext> messageProduceError;
+        private readonly Event<MessageEventContext> messageProduceStarted;
+
+        public GlobalEvents(ILogHandler log)
+        {
+            this.messageConsumeCompleted = new(log);
+            this.messageConsumeError = new(log);
+            this.messageConsumeStarted = new(log);
+            this.messageProduceCompleted = new(log);
+            this.messageProduceError = new(log);
+            this.messageProduceStarted = new(log);
+        }
+
+        public IEvent<MessageEventContext> MessageConsumeCompleted => this.messageConsumeCompleted;
+
+        public IEvent<MessageErrorEventContext> MessageConsumeError => this.messageConsumeError;
+
+        public IEvent<MessageEventContext> MessageConsumeStarted => this.messageConsumeStarted;
+
+        public IEvent<MessageEventContext> MessageProduceCompleted => this.messageProduceCompleted;
+
+        public IEvent<MessageErrorEventContext> MessageProduceError => this.messageProduceError;
+
+        public IEvent<MessageEventContext> MessageProduceStarted => this.messageProduceStarted;
+
+        public Task FireMessageConsumeStartedAsync(MessageEventContext context)
+            => this.messageConsumeStarted.FireAsync(context);
+
+        public Task FireMessageConsumeErrorAsync(MessageErrorEventContext context)
+            => this.messageConsumeError.FireAsync(context);
+
+        public Task FireMessageConsumeCompletedAsync(MessageEventContext context)
+            => this.messageConsumeCompleted.FireAsync(context);
+
+        public Task FireMessageProduceStartedAsync(MessageEventContext context)
+            => this.messageProduceStarted.FireAsync(context);
+
+        public Task FireMessageProduceErrorAsync(MessageErrorEventContext context)
+           => this.messageProduceError.FireAsync(context);
+
+        public Task FireMessageProduceCompletedAsync(MessageEventContext context)
+            => this.messageProduceCompleted.FireAsync(context);
+
+    }
+}

--- a/src/KafkaFlow/MessageContext.cs
+++ b/src/KafkaFlow/MessageContext.cs
@@ -1,5 +1,7 @@
 namespace KafkaFlow
 {
+    using System.Collections.Generic;
+
     internal class MessageContext : IMessageContext
     {
         public MessageContext(
@@ -12,6 +14,7 @@ namespace KafkaFlow
             this.Headers = headers ?? new MessageHeaders();
             this.ConsumerContext = consumer;
             this.ProducerContext = producer;
+            this.Items = new Dictionary<string, object>();
         }
 
         public Message Message { get; }
@@ -21,6 +24,8 @@ namespace KafkaFlow
         public IProducerContext ProducerContext { get; }
 
         public IMessageHeaders Headers { get; }
+
+        public IDictionary<string, object> Items { get; }
 
         public IMessageContext SetMessage(object key, object value) => new MessageContext(
             new Message(key, value),

--- a/website/docs/guides/configuration.md
+++ b/website/docs/guides/configuration.md
@@ -8,7 +8,7 @@ In this section, we will introduce how configuration is done in KafkaFlow.
 
 KafkaFlow is a highly configured framework. You can customize it through a Fluent Builder.
 
-Using the builder, you can configure [Logging](../guides/logging.md), Clusters, Producers, Consumers and others.
+Using the builder, you can configure [Logging](../guides/logging.md), [Global Events](../guides/global-events.md), Clusters, Producers, Consumers and others.
 
 There are a few options to configure KafkaFlow:
   - [Using a Hosted Service](#hosted-service)

--- a/website/docs/guides/global-events.md
+++ b/website/docs/guides/global-events.md
@@ -1,0 +1,115 @@
+---
+sidebar_position: 9
+---
+
+# Global Events
+
+In this section, we will delve into the concept of Global Events in KafkaFlow, which provides a mechanism to subscribe to various events that are triggered during the message production and consumption processes. 
+
+KafkaFlow offers a range of Global Events that can be subscribed to. These events can be used to monitor and react to different stages of message handling. Below is a list of available events:
+  - [Message Produce Started Event](#message-produce-started-event)
+  - [Message Produce Completed Event](#message-produce-completed-event)
+  - [Message Produce Error Event](#message-produce-error-event)
+  - [Message Consume Started Event](#message-consume-started-event)
+  - [Message Consume Completed Event](#message-consume-completed-event)
+  - [Message Consume Error Event](#message-consume-error-event)
+
+## Message Produce Started Event {#message-produce-started-event}
+
+The Message Produce Started Event is triggered when the message production process begins. It provides an opportunity to perform tasks or gather information before middlewares execution.
+
+```csharp
+services.AddKafka(
+    kafka => kafka
+        .SubscribeGlobalEvents(observers =>
+        {
+            observers.MessageProduceStarted.Subscribe(eventContext =>
+            {
+                // Add your logic here
+            });
+        })
+```
+
+## Message Produce Completed Event {#message-produce-completed-event}
+
+The Message Produce Completed Event is triggered when a message is successfully produced or when error messages occur during the production process. Subscribing to this event enables you to track the successful completion of message production.
+
+```csharp
+services.AddKafka(
+    kafka => kafka
+        .SubscribeGlobalEvents(observers =>
+        {
+            observers.MessageProduceCompleted.Subscribe(eventContext =>
+            {
+                // Add your logic here
+            });
+        })
+```
+
+## Message Produce Error Event {#message-produce-error-event}
+
+In case an error occurs during message production, the Message Produce Error Event is triggered. By subscribing to this event, you will be able to catch any exceptions that may occur while producing a message.
+
+```csharp
+services.AddKafka(
+    kafka => kafka
+        .SubscribeGlobalEvents(observers =>
+        {
+            observers.MessageProduceError.Subscribe(eventContext =>
+            {
+                // Add your logic here
+            });
+        })
+```
+
+## Message Consume Started Event {#message-consume-started-event}
+
+The Message Consume Started Event is raised at the beginning of the message consumption process. It offers an opportunity to execute specific tasks or set up resources before message processing begins.
+
+```csharp
+services.AddKafka(
+    kafka => kafka
+        .SubscribeGlobalEvents(observers =>
+        {
+            observers.MessageConsumeStarted.Subscribe(eventContext =>
+            {
+                // Add your logic here
+            });
+        })
+```
+
+## Message Consume Completed Event {#message-consume-completed-event}
+
+The Message Consume Completed Event signals the successful completion of message consumption. By subscribing to this event, you can track when messages have been successfully processed.
+
+:::info
+Please note that the current event is not compatible with Batch Consume in the current version (v2). However, this limitation is expected to be addressed in future releases (v3+).
+:::info
+
+```csharp
+services.AddKafka(
+    kafka => kafka
+        .SubscribeGlobalEvents(observers =>
+        {
+            observers.MessageProduceCompleted.Subscribe(eventContext =>
+            {
+                // Add your logic here
+            });
+        })
+```
+
+## Message Consume Error Event {#message-consume-error-event}
+
+If an error occurs during message consumption, the Message Consume Error Event is triggered. Subscribing to this event allows you to manage and respond to consumption errors.
+
+```csharp
+services.AddKafka(
+    kafka => kafka
+        .SubscribeGlobalEvents(observers =>
+        {
+            observers.MessageConsumeError.Subscribe(eventContext =>
+            {
+                // Add your logic here
+            });
+        })
+```

--- a/website/docs/guides/open-telemetry.md
+++ b/website/docs/guides/open-telemetry.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 10
+---
+
+# OpenTelemetry instrumentation
+
+KafkaFlow includes support for [Traces](https://opentelemetry.io/docs/concepts/signals/traces/) and [Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) signals using [OpenTelemetry instrumentation](https://opentelemetry.io/docs/instrumentation/net/).
+
+## Including OpenTelemetry instrumentation in your code
+
+Add the package [KafkaFlow.OpenTelemetry](https://www.nuget.org/packages/KafkaFlow.OpenTelemetry/) to the project and add the extension method `AddOpenTelemetryInstrumentation` in your Startup:
+
+```csharp
+services.AddKafka(
+    kafka => kafka
+        .AddCluster(...)
+        .AddOpenTelemetryInstrumentation()
+);
+```
+
+## Using KafkaFlow instrumentation with .NET Automatic Instrumentation
+
+When using [.NET automatic instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation), the KafkaFlow activity can be captured by including the ActivitySource name `KafkaFlow.OpenTelemetry` as a parameter to the variable `OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES`.

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -27,6 +27,8 @@ To do that, KafkaFlow gives you access to features like:
 -   [Serializer middleware](guides/middlewares/serializer-middleware.md) with **ApacheAvro**, **ProtoBuf** and **Json** algorithms.
 -   [Schema Registry](guides/middlewares/serializer-middleware.md#adding-schema-registry-support) support.
 -   [Compression](guides/compression.md) using native Confluent Kafka client compression or compressor middleware.
+-   [Global Events Subcription](guides/global-events.md) for message production and consumption.
+-   [Open Telemetry Instrumentation](guides/open-telemetry.md) for traces and baggage signals.
 -   Graceful shutdown (wait to finish processing to shutdown).
 -   Store offset when processing ends, avoiding message loss.
 -   Supports .NET Core and .NET Framework.


### PR DESCRIPTION
# Description

Includes several changes that allow telemetry events to be created when producing and consuming messages:

- Includes an event system that notifies the listeners of the following events

1. Message consume start
2. Message consume complete
3. Message consume error
4. Message produce start
5. Message produce complete
6. Message produce error

- Includes a new project `KafkaFlow.OpenTelemetry` that can be used to export trace information regarding the internal kafka events mentioned above.

*Note:* The trace information may not be reliable when using batch consumers. This drawback is scheduled to be solved in a new major version https://github.com/Farfetch/kafkaflow/tree/release/3.0

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
