### PR TITLE
Create GH Workflow to generate Metrics Reports

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,99 @@
+name: Monthly Metrics
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '3 2 1 * *'
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    name: Calculate Metrics
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Get dates for last month
+      id: get-dates
+      shell: bash
+      run: |
+        # Calculate the first day of the previous month
+        first_day=$(date -d "last month" +%Y-%m-01)
+
+        # Calculate the last day of the previous month
+        last_day=$(date -d "$first_day +1 month -1 day" +%Y-%m-%d)
+
+        # Calculate the previous month
+        previous_date=$(date -d "$current_date -1 month" +'%Y-%m-%d')
+
+        # Put the report month and year in the environment
+        echo report_month="$(date -d "$previous_date" +'%B') $(date -d "$previous_date" +'%Y')" >> "$GITHUB_ENV"
+
+        #Set an environment variable with the date range
+        echo "$first_day..$last_day"
+        echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
+
+    - name: Run issue-metrics tool for items opened last month
+      id: opened-metrics
+      uses: github/issue-metrics@v2
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SEARCH_QUERY: 'repo:farfetch/kafkaflow created:${{ env.last_month }} -reason:"not planned"'
+
+    - name: Create issue for opened items 
+      uses: peter-evans/create-issue-from-file@v4
+      with:
+        title: "[Metrics] Opened in ${{ env.report_month }}"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        content-filepath: ./issue_metrics.md
+        assignees: ${{ vars.TEAM_MEMBERS }}
+        labels: metrics
+
+    - name: Run issue-metrics tool for items closed last month
+      id: closed-metrics
+      uses: github/issue-metrics@v2
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SEARCH_QUERY: 'repo:farfetch/kafkaflow closed:${{ env.last_month }} -reason:"not planned"'
+
+    - name: Create issue for closed items
+      uses: peter-evans/create-issue-from-file@v4
+      with:
+        title: "[Metrics] Closed in ${{ env.report_month }}"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        content-filepath: ./issue_metrics.md
+        assignees: ${{ vars.TEAM_MEMBERS }}
+        labels: metrics
+
+    - name: Run issue-metrics tool for discussions opened last month
+      id: opened-discussions-metrics
+      uses: github/issue-metrics@v2
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SEARCH_QUERY: 'repo:farfetch/kafkaflow type:discussions created:${{ env.last_month }} -reason:"not planned"'
+
+    - name: Create issue for opened discussions
+      uses: peter-evans/create-issue-from-file@v4
+      with:
+        title: "[Metrics] Opened Discussions in ${{ env.report_month }}"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        content-filepath: ./issue_metrics.md
+        assignees: ${{ vars.TEAM_MEMBERS }}
+        labels: metrics
+
+    - name: Run issue-metrics tool for discussions closed last month
+      id: closed-discussions-metrics
+      uses: github/issue-metrics@v2
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SEARCH_QUERY: 'repo:farfetch/kafkaflow type:discussions closed:${{ env.last_month }} -reason:"not planned"'
+
+    - name: Create issue for closed discussions
+      uses: peter-evans/create-issue-from-file@v4
+      with:
+        title: "[Metrics] Closed Discussions in ${{ env.report_month }}"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        content-filepath: ./issue_metrics.md
+        assignees: ${{ vars.TEAM_MEMBERS }}
+        labels: metrics

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,6 +1,9 @@
 name: Monthly Metrics
 on:
   workflow_dispatch:
+    inputs:
+      dates:
+        required: false
   schedule:
     - cron: '3 2 1 * *'
 
@@ -20,19 +23,18 @@ jobs:
       run: |
         # Calculate the first day of the previous month
         first_day=$(date -d "last month" +%Y-%m-01)
-
         # Calculate the last day of the previous month
         last_day=$(date -d "$first_day +1 month -1 day" +%Y-%m-%d)
-
-        # Calculate the previous month
-        previous_date=$(date -d "$current_date -1 month" +'%Y-%m-%d')
-
-        # Put the report month and year in the environment
-        echo report_month="$(date -d "$previous_date" +'%B') $(date -d "$previous_date" +'%Y')" >> "$GITHUB_ENV"
-
         #Set an environment variable with the date range
         echo "$first_day..$last_day"
         echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
+    
+    - name: Use input dates
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dates != '' }}
+      shell: bash
+      run: |
+        echo "${{github.event.inputs.dates}}"
+        echo "last_month=${{github.event.inputs.dates}}" >> "$GITHUB_ENV"
 
     - name: Run issue-metrics tool for items opened last month
       id: opened-metrics

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -41,14 +41,11 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:farfetch/kafkaflow created:${{ env.last_month }} -reason:"not planned"'
 
-    - name: Create issue for opened items 
-      uses: peter-evans/create-issue-from-file@v4
+    - name: Upload for opened items 
+      uses: actions/upload-artifact@v3
       with:
-        title: "[Metrics] Opened in ${{ env.report_month }}"
-        token: ${{ secrets.GITHUB_TOKEN }}
-        content-filepath: ./issue_metrics.md
-        assignees: ${{ vars.TEAM_MEMBERS }}
-        labels: metrics
+        name: items-opened
+        path: ./issue_metrics.md
 
     - name: Run issue-metrics tool for items closed last month
       id: closed-metrics
@@ -57,14 +54,11 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:farfetch/kafkaflow closed:${{ env.last_month }} -reason:"not planned"'
 
-    - name: Create issue for closed items
-      uses: peter-evans/create-issue-from-file@v4
+    - name: Upload for closed items
+      uses: actions/upload-artifact@v3
       with:
-        title: "[Metrics] Closed in ${{ env.report_month }}"
-        token: ${{ secrets.GITHUB_TOKEN }}
-        content-filepath: ./issue_metrics.md
-        assignees: ${{ vars.TEAM_MEMBERS }}
-        labels: metrics
+        name: items-closed
+        path: ./issue_metrics.md
 
     - name: Run issue-metrics tool for discussions opened last month
       id: opened-discussions-metrics
@@ -73,14 +67,11 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:farfetch/kafkaflow type:discussions created:${{ env.last_month }} -reason:"not planned"'
 
-    - name: Create issue for opened discussions
-      uses: peter-evans/create-issue-from-file@v4
+    - name: Upload for opened discussions
+      uses: actions/upload-artifact@v3
       with:
-        title: "[Metrics] Opened Discussions in ${{ env.report_month }}"
-        token: ${{ secrets.GITHUB_TOKEN }}
-        content-filepath: ./issue_metrics.md
-        assignees: ${{ vars.TEAM_MEMBERS }}
-        labels: metrics
+        name: discussions-opened
+        path: ./issue_metrics.md
 
     - name: Run issue-metrics tool for discussions closed last month
       id: closed-discussions-metrics
@@ -89,11 +80,8 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:farfetch/kafkaflow type:discussions closed:${{ env.last_month }} -reason:"not planned"'
 
-    - name: Create issue for closed discussions
-      uses: peter-evans/create-issue-from-file@v4
+    - name: Upload for closed discussions
+      uses: actions/upload-artifact@v3
       with:
-        title: "[Metrics] Closed Discussions in ${{ env.report_month }}"
-        token: ${{ secrets.GITHUB_TOKEN }}
-        content-filepath: ./issue_metrics.md
-        assignees: ${{ vars.TEAM_MEMBERS }}
-        labels: metrics
+        name: discussions-closed
+        path: ./issue_metrics.md


### PR DESCRIPTION
# Description

Keep track of metrics like:
- Average time to first response
- Average time to close 
- Number of items that remain open
- Number of items closed
- Total number of items created

The implementation uses [GitHub issue-metrics workflow](https://github.com/github/issue-metrics).
The GitHub Action will be executed on the first day of the month and generate 4 markdown files based on the last month's data:
 1. Opened Items (contains PRs and Issues)
 2. Closed Items (contains PRs and Issues)
 3. Opened Discussions
 4. Closed Discussions

The files will be attached to the GH Action as artifacts.

Due to the way that the Action works, we can't combine data into a single file.

**Manual Trigger:** It's possible to input the date range using the following format `2023-08-01..2023-08-31`. Leave it empty to calculate for the past month.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
