### PR TITLE
chore: remove conditional reference to librdkafka.redist

### DIFF
--- a/src/KafkaFlow.IntegrationTests/KafkaFlow.IntegrationTests.csproj
+++ b/src/KafkaFlow.IntegrationTests/KafkaFlow.IntegrationTests.csproj
@@ -28,11 +28,6 @@
 		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.6.0" />
 		<PackageReference Include="Polly" Version="8.0.0" />
     </ItemGroup>
-    
-    <ItemGroup Condition="$([MSBuild]::IsOsPlatform('OSX'))">
-        <PackageReference Include="librdkafka.redist" Version="1.9.2" />
-    </ItemGroup>
-    
 
     <ItemGroup>
         <ProjectReference Include="..\KafkaFlow.Abstractions\KafkaFlow.Abstractions.csproj" />


### PR DESCRIPTION
# Description

The PR #295 introduced a conditional reference for macOS related to the issue [here](https://github.com/confluentinc/confluent-kafka-dotnet/issues/778#issuecomment-470276460).

Version [2.4.0](https://github.com/Farfetch/kafkaflow/releases/tag/2.4.0) updated confluent packages, eliminating this problem.

Fixes #458 

## How Has This Been Tested?

Try to reproduce the issue on macOS.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
