### PR TITLE
fix: broken traces

### DIFF
--- a/src/KafkaFlow.Abstractions/ActivityOperationType.cs
+++ b/src/KafkaFlow.Abstractions/ActivityOperationType.cs
@@ -1,0 +1,12 @@
+﻿namespace KafkaFlow
+{
+    /// <summary>Activity operation names enum values</summary>
+    public enum ActivityOperationType
+    {
+        /// <summary>PUBLISH</summary>
+        Publish,
+
+        /// <summary>PROCESS</summary>
+        Process,
+    }
+}

--- a/src/KafkaFlow.Abstractions/ActivitySourceAccessor.cs
+++ b/src/KafkaFlow.Abstractions/ActivitySourceAccessor.cs
@@ -1,0 +1,28 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+
+namespace KafkaFlow
+{
+    /// <summary>
+    /// ActivitySource properties
+    /// </summary>
+    public static class ActivitySourceAccessor
+    {
+        internal static readonly string Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+
+        private const string _activityString = "otel_activity";
+
+        private static readonly ActivitySource _activitySource = new("KafkaFlow.OpenTelemetry", Version);
+
+        /// <summary>
+        /// Gets the name of the OpenTelemetry Activity that is used as a key
+        /// in MessageContext.Items dictionary
+        /// </summary>
+        public static string ActivityString => _activityString;
+
+        /// <summary>
+        /// Gets the ActivitySource name that is used in KafkaFlow
+        /// </summary>
+        public static ActivitySource ActivitySource => _activitySource;
+    }
+}

--- a/src/KafkaFlow.Abstractions/KafkaFlow.Abstractions.csproj
+++ b/src/KafkaFlow.Abstractions/KafkaFlow.Abstractions.csproj
@@ -7,4 +7,8 @@
         <Description>Contains all KafkaFlow extendable interfaces</Description>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
+    </ItemGroup>
+
 </Project>

--- a/src/KafkaFlow.IntegrationTests/Core/Middlewares/GzipMiddleware.cs
+++ b/src/KafkaFlow.IntegrationTests/Core/Middlewares/GzipMiddleware.cs
@@ -1,5 +1,6 @@
 namespace KafkaFlow.IntegrationTests.Core.Middlewares
 {
+    using System.Diagnostics;
     using System.Threading.Tasks;
     using KafkaFlow.IntegrationTests.Core.Handlers;
 
@@ -7,6 +8,8 @@ namespace KafkaFlow.IntegrationTests.Core.Middlewares
     {
         public async Task Invoke(IMessageContext context, MiddlewareDelegate next)
         {
+            using var activity = ActivitySourceAccessor.ActivitySource.StartActivity("integration-test", ActivityKind.Internal);
+
             MessageStorage.Add((byte[]) context.Message.Value);
             await next(context);
         }

--- a/src/KafkaFlow.IntegrationTests/OpenTelemetryTests.cs
+++ b/src/KafkaFlow.IntegrationTests/OpenTelemetryTests.cs
@@ -56,12 +56,41 @@
             await producer.ProduceAsync(null, message);
 
             // Assert
-            var (producerSpan, consumerSpan) = await this.WaitForSpansAsync();
+            var (producerSpan, consumerSpan, internalSpan) = await this.WaitForSpansAsync();
 
             Assert.IsNotNull(this.exportedItems);
             Assert.IsNull(producerSpan.ParentId);
             Assert.AreEqual(producerSpan.TraceId, consumerSpan.TraceId);
             Assert.AreEqual(consumerSpan.ParentSpanId, producerSpan.SpanId);
+        }
+
+        [TestMethod]
+        public async Task AddOpenTelemetry_CreateActivityOnConsumingMessage_TraceIsPropagatedToCreatedActivity()
+        {
+            // Arrange
+            var provider = await this.GetServiceProvider();
+            MessageStorage.Clear();
+
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("KafkaFlow.OpenTelemetry")
+            .AddInMemoryExporter(this.exportedItems)
+            .Build();
+
+            var producer = provider.GetRequiredService<IMessageProducer<GzipProducer>>();
+            var message = this.fixture.Create<byte[]>();
+
+            // Act
+            await producer.ProduceAsync(null, message);
+
+            // Assert
+            var (producerSpan, consumerSpan, internalSpan) = await this.WaitForSpansAsync();
+
+            Assert.IsNotNull(this.exportedItems);
+            Assert.IsNull(producerSpan.ParentId);
+            Assert.AreEqual(producerSpan.TraceId, consumerSpan.TraceId);
+            Assert.AreEqual(consumerSpan.ParentSpanId, producerSpan.SpanId);
+            Assert.AreEqual(internalSpan.TraceId, consumerSpan.TraceId);
+            Assert.AreEqual(internalSpan.ParentSpanId, consumerSpan.SpanId);
         }
 
         [TestMethod]
@@ -97,7 +126,7 @@
             await producer.ProduceAsync(null, message);
 
             // Assert
-            var (producerSpan, consumerSpan) = await this.WaitForSpansAsync();
+            var (producerSpan, consumerSpan, internalSpan) = await this.WaitForSpansAsync();
 
             Assert.IsNotNull(this.exportedItems);
             Assert.AreEqual(producerSpan.TraceId, consumerSpan.TraceId);
@@ -181,9 +210,9 @@
                 .ExecuteAsync(() => Task.FromResult(this.isPartitionAssigned));
         }
 
-        private async Task<(Activity producerSpan, Activity consumerSpan)> WaitForSpansAsync()
+        private async Task<(Activity producerSpan, Activity consumerSpan, Activity internalSpan)> WaitForSpansAsync()
         {
-            Activity producerSpan = null, consumerSpan = null;
+            Activity producerSpan = null, consumerSpan = null, internalSpan = null;
 
             await Policy
                 .HandleResult<bool>(isAvailable => !isAvailable)
@@ -192,11 +221,12 @@
                 {
                     producerSpan = this.exportedItems.Find(x => x.Kind == ActivityKind.Producer);
                     consumerSpan = this.exportedItems.Find(x => x.Kind == ActivityKind.Consumer);
+                    internalSpan = this.exportedItems.Find(x => x.Kind == ActivityKind.Internal);
 
                     return Task.FromResult(producerSpan != null && consumerSpan != null);
                 });
 
-            return (producerSpan, consumerSpan);
+            return (producerSpan, consumerSpan, internalSpan);
         }
     }
 }

--- a/src/KafkaFlow.OpenTelemetry/ActivityAccessor.cs
+++ b/src/KafkaFlow.OpenTelemetry/ActivityAccessor.cs
@@ -5,21 +5,15 @@ namespace KafkaFlow.OpenTelemetry
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Reflection;
     using Conventions = SemanticConventions::OpenTelemetry.Trace.TraceSemanticConventions;
 
-    internal static class ActivitySourceAccessor
+    internal static class ActivityAccessor
     {
-        internal const string ActivityString = "otel_activity";
         internal const string ExceptionEventKey = "exception";
         internal const string MessagingSystemId = "kafka";
         internal const string AttributeMessagingOperation = "messaging.operation";
         internal const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
         internal const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
-        internal static readonly AssemblyName AssemblyName = typeof(ActivitySourceAccessor).Assembly.GetName();
-        internal static readonly string ActivitySourceName = AssemblyName.Name;
-        internal static readonly string Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version);
 
         public static void SetGenericTags(Activity activity)
         {

--- a/src/KafkaFlow.OpenTelemetry/OpenTelemetryConsumerEventsHandler.cs
+++ b/src/KafkaFlow.OpenTelemetry/OpenTelemetryConsumerEventsHandler.cs
@@ -20,25 +20,23 @@
         {
             try
             {
-                var activityName = !string.IsNullOrEmpty(context?.ConsumerContext.Topic) ? $"{context?.ConsumerContext.Topic} {ProcessString}" : ProcessString;
-
                 // Extract the PropagationContext of the upstream parent from the message headers.
                 var parentContext = Propagator.Extract(new PropagationContext(default, Baggage.Current), context, ExtractTraceContextIntoBasicProperties);
                 Baggage.Current = parentContext.Baggage;
 
-                // Start an activity with a name following the semantic convention of the OpenTelemetry messaging specification.
-                // The convention also defines a set of attributes (in .NET they are mapped as `tags`) to be populated in the activity.
-                // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md
-                var activity = ActivitySourceAccessor.ActivitySource.StartActivity(activityName, ActivityKind.Consumer, parentContext.ActivityContext);
+                var activity = context.Items[ActivitySourceAccessor.ActivityString] as Activity;
+
+                if (parentContext.ActivityContext.IsValid())
+                {
+                    activity.SetParentId(parentContext.ActivityContext.TraceId, parentContext.ActivityContext.SpanId, parentContext.ActivityContext.TraceFlags);
+                }
 
                 foreach (var item in Baggage.Current)
                 {
                     activity?.AddBaggage(item.Key, item.Value);
                 }
 
-                context?.Items.Add(ActivitySourceAccessor.ActivityString, activity);
-
-                ActivitySourceAccessor.SetGenericTags(activity);
+                ActivityAccessor.SetGenericTags(activity);
 
                 if (activity != null && activity.IsAllDataRequested)
                 {
@@ -57,7 +55,7 @@
         {
             if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
             {
-                activity?.Dispose();
+                activity?.Stop();
             }
 
             return Task.CompletedTask;
@@ -67,11 +65,11 @@
         {
             if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
             {
-                var exceptionEvent = ActivitySourceAccessor.CreateExceptionEvent(ex);
+                var exceptionEvent = ActivityAccessor.CreateExceptionEvent(ex);
 
                 activity?.AddEvent(exceptionEvent);
 
-                activity?.Dispose();
+                activity?.Stop();
             }
 
             return Task.CompletedTask;
@@ -86,11 +84,11 @@
         {
             var messageKey = Encoding.UTF8.GetString(context.Message.Key as byte[]);
 
-            activity.SetTag(ActivitySourceAccessor.AttributeMessagingOperation, ProcessString);
+            activity.SetTag(ActivityAccessor.AttributeMessagingOperation, ActivityOperationType.Process.ToString().ToLower());
             activity.SetTag(AttributeMessagingSourceName, context.ConsumerContext.Topic);
             activity.SetTag(AttributeMessagingKafkaConsumerGroup, context.ConsumerContext.GroupId);
-            activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageKey, messageKey);
-            activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageOffset, context.ConsumerContext.Offset);
+            activity.SetTag(ActivityAccessor.AttributeMessagingKafkaMessageKey, messageKey);
+            activity.SetTag(ActivityAccessor.AttributeMessagingKafkaMessageOffset, context.ConsumerContext.Offset);
             activity.SetTag(AttributeMessagingKafkaSourcePartition, context.ConsumerContext.Partition);
         }
     }

--- a/src/KafkaFlow/ActivityFactory.cs
+++ b/src/KafkaFlow/ActivityFactory.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics;
+
+namespace KafkaFlow
+{
+    internal static class ActivityFactory
+    {
+        public static Activity Start(string topicName, ActivityOperationType activityOperationType, ActivityKind activityKind)
+        {
+            var activityName = !string.IsNullOrEmpty(topicName) ? $"{topicName} {activityOperationType}" : activityOperationType.ToString().ToLower();
+
+            // Start an activity with a name following the semantic convention of the OpenTelemetry messaging specification.
+            // The convention also defines a set of attributes (in .NET they are mapped as `tags`) to be populated in the activity.
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md
+            return ActivitySourceAccessor.ActivitySource.StartActivity(activityName, activityKind);
+        }
+    }
+}

--- a/src/KafkaFlow/Consumers/ConsumerWorker.cs
+++ b/src/KafkaFlow/Consumers/ConsumerWorker.cs
@@ -1,6 +1,7 @@
 namespace KafkaFlow.Consumers
 {
     using System;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Channels;
     using System.Threading.Tasks;
@@ -106,6 +107,8 @@ namespace KafkaFlow.Consumers
 
         private async Task ProcessMessageAsync(ConsumeResult<byte[], byte[]> message, CancellationToken cancellationToken)
         {
+            var activity = ActivityFactory.Start(message.Topic, ActivityOperationType.Process, ActivityKind.Consumer);
+
             try
             {
                 var context = new MessageContext(
@@ -118,6 +121,8 @@ namespace KafkaFlow.Consumers
                         cancellationToken,
                         this.Id),
                     null);
+
+                context.Items.Add(ActivitySourceAccessor.ActivityString, activity);
 
                 try
                 {

--- a/src/KafkaFlow/KafkaFlow.csproj
+++ b/src/KafkaFlow/KafkaFlow.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Confluent.Kafka" Version="2.1.1" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
         <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
     </ItemGroup>
 


### PR DESCRIPTION
# Description

Fixes broken traces by changing the Activity creation to `KafkaFlow` project, just before the messages are consumed and produced.

The error appeared because the Activity context, being created in `KafkaFlow.OpenTelemetry`, could not be propagated through the system and the next time a span would be created the existing Activity would be null, forcing the creation of a new trace instead of using the previous one

Closes https://github.com/Farfetch/kafkaflow/issues/468

## How Has This Been Tested?

Integration tests

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
