### PR TITLE
docs: community resources page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -75,6 +75,11 @@ const config = {
             position: 'right'
           },
           {
+            to: 'community', 
+            label: 'Community', 
+            position: 'right'
+          },
+          {
             href: 'https://github.com/farfetch/kafkaflow',
             label: 'GitHub',
             position: 'right',

--- a/website/src/components/Community/Resource/Index.js
+++ b/website/src/components/Community/Resource/Index.js
@@ -1,0 +1,37 @@
+import React from "react";
+
+export function Resource({ title, description, link, type, date, authors }) {
+  return (
+    <div class="card-demo padding-top--md">
+      <div class="card">
+        <div class="card__header">
+          <h3>
+            {type}: {title}
+          </h3>
+        </div>
+        <div class="card__body">
+          <p>
+            <small>
+              By: 
+              {authors.map(({ name, url }, index) => (
+                <>
+                  <span>{index ? ", " : ""}</span>
+                  <a href={url} title={name}>
+                    {name}
+                  </a>
+                </>
+              ))}
+              <br />
+              {date}
+            </small>
+          </p>
+          {description ? <p>{description}</p> : <></>}
+          <p></p>
+          <a title={title} href={link}>
+            {link}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/pages/community/index.js
+++ b/website/src/pages/community/index.js
@@ -1,0 +1,146 @@
+import React from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Layout from "@theme/Layout";
+import { Resource } from "../../components/Community/Resource/Index";
+
+const resources = [
+  {
+    title:
+      "[PORTUGUESE] KafkaFlow, An open-source Kafka framework for .NET : Live Demo",
+    description: null,
+    link: "https://www.youtube.com/watch?v=XJCoI38KK7o",
+    type: "Talk",
+    date: "2021-12-15",
+    authors: [
+      {
+        name: "Filipe Esch",
+        url: "https://github.com/filipeesch",
+      },
+    ],
+  },
+  {
+    title: "A BETTER Way to Kafka Event Diven Applications with C#",
+    description: null,
+    link: "https://www.youtube.com/watch?v=4e18DZkf-m0",
+    type: "Video",
+    date: "2023-01-24",
+    authors: [
+      {
+        name: "Gui Ferreira",
+        url: "https://guiferreira.me",
+      },
+    ],
+  },
+  {
+    title:
+      "Apache Kafka in 1 hour for C# Developers - Guilherme Ferreira - NDC London 2023",
+    description: null,
+    link: "https://www.youtube.com/watch?v=4xpjlqIlfY8",
+    type: "Talk",
+    date: "2023-05-20",
+    authors: [
+      {
+        name: "Gui Ferreira",
+        url: "https://guiferreira.me",
+      },
+    ],
+  },
+  {
+    title: "3 KafkaFlow Features Hard to Ignore",
+    description: null,
+    link: "https://www.youtube.com/watch?v=v-aFkzlBVpE",
+    type: "Video",
+    date: "2023-06-20",
+    authors: [
+      {
+        name: "Gui Ferreira",
+        url: "https://guiferreira.me",
+      },
+    ],
+  },
+  {
+    title: "How KafkaFlow Supercharged FARFETCH's Event-Driven Architecture",
+    description: null,
+    link: "https://www.farfetchtechblog.com/en/blog/post/how-kafkaflow-supercharged-farfetch-s-event-driven-architecture/",
+    type: "Article",
+    date: "2023-08-25",
+    authors: [
+      {
+        name: "Filipe Esch",
+        url: "https://github.com/filipeesch",
+      },
+      {
+        name: "Gui Ferreira",
+        url: "https://guiferreira.me",
+      },
+    ],
+  },
+  {
+    title: "Building Kafka Event-Driven Applications with KafkaFlow",
+    description: null,
+    link: "https://www.infoq.com/articles/kafkaflow-dotnet-framework/",
+    type: "Article",
+    date: "2023-09-08",
+    authors: [
+      {
+        name: "Gui Ferreira",
+        url: "https://guiferreira.me",
+      },
+    ],
+  },
+  {
+    title:
+      "Apache Kafka in 1 hour for C# Developers - Guilherme Ferreira - Copenhagen DevFest 2023",
+    description: null,
+    link: "https://www.youtube.com/watch?v=E07CGvGVal8",
+    type: "Talk",
+    date: "2023-11-08",
+    authors: [
+      {
+        name: "Gui Ferreira",
+        url: "https://guiferreira.me",
+      },
+    ],
+  },
+];
+
+export default function Community() {
+  const { siteConfig } = useDocusaurusContext();
+
+  return (
+    <Layout
+      title={`Community | ${siteConfig.title}`}
+      description="KafkaFlow resources built by the community"
+    >
+      <main>
+        <div class="container padding-top--md padding-bottom--lg">
+          <div class="row">
+            <div class="col">
+              <article>
+                <h1>Community</h1>
+                <p>Resources built by the community.</p>
+                <div class="alert alert--info" role="alert">
+                  If you have any resource (blog post, talk, podcast, etc.)
+                  where KafkaFlow is mentioned and you want to see it listed
+                  here, please let us know{" "}
+                  <a href="https://github.com/Farfetch/kafkaflow/issues">
+                    (here)
+                  </a>
+                  .
+                </div>
+
+                <div class="row">
+                  <div class="col">
+                    {resources.map((props, idx) => (
+                      <Resource key={idx} {...props} />
+                    ))}
+                  </div>
+                </div>
+              </article>
+            </div>
+          </div>
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
# Description

Create a page to track community resources such as videos, articles, podcasts, conference talks, meetups, etc.
The goal is to create a central repository where the community can not only promote resources but also find useful information when learning KafkaFlow.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
