### PR TITLE
Add distribution strategy from partition key

### DIFF
--- a/src/KafkaFlow/Consumers/DistributionStrategies/BytesSumDistributionStrategy.cs
+++ b/src/KafkaFlow/Consumers/DistributionStrategies/BytesSumDistributionStrategy.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 namespace KafkaFlow.Consumers.DistributionStrategies;
 
 /// <summary>
-/// This strategy sums all bytes in the partition key and apply a mod operator with the total number of workers, the resulting number is the worker ID to be chosen
-/// This algorithm is fast and creates a good work balance. Messages with the same partition key are always delivered in the same worker, so, message order is guaranteed
-/// Set an optimal message buffer value to avoid idle workers (it will depends how many messages with the same partition key are consumed)
+/// This strategy sums all bytes in the message key and apply a mod operator with the total number of workers, the resulting number is the worker ID to be chosen
+/// This algorithm is fast and creates a good work balance. Messages with the same message key are always delivered in the same worker.
+/// Set an optimal message buffer value to avoid idle workers (it will depends how many messages with the same message key are consumed)
 /// </summary>
 public class BytesSumDistributionStrategy : IWorkerDistributionStrategy
 {

--- a/src/KafkaFlow/Consumers/DistributionStrategies/PartitionKeyDistributionStrategy.cs
+++ b/src/KafkaFlow/Consumers/DistributionStrategies/PartitionKeyDistributionStrategy.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace KafkaFlow.Consumers.DistributionStrategies;
+
+/// <summary>
+/// This strategy applies a mod operator to the partition key and the total number of workers, the resulting number is the worker ID to be chosen
+/// This algorithm is fast and creates a good work balance. Messages with the same partition key are always delivered in the same worker, so, message order is guaranteed
+/// In cases where the number of partitions assigned to the consumer is small, this strategy can limit the number of available workers to distribute the messages.
+/// </summary>
+public class PartitionKeyDistributionStrategy : IWorkerDistributionStrategy
+{
+    private IReadOnlyList<IWorker> _workers;
+
+    /// <inheritdoc />
+    public void Initialize(IReadOnlyList<IWorker> workers)
+    {
+        _workers = workers;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IWorker> GetWorkerAsync(WorkerDistributionContext context)
+    {
+        if (_workers.Count == 1)
+        {
+            return new ValueTask<IWorker>(_workers[0]);
+        }
+
+        return new ValueTask<IWorker>(
+            context.ConsumerStoppedCancellationToken.IsCancellationRequested
+                ? null
+                : _workers.ElementAtOrDefault(context.Partition % _workers.Count));
+    }
+}

--- a/tests/KafkaFlow.UnitTests/Consumer/DistributionStrategies/BytesSumDistributionStrategyTests.cs
+++ b/tests/KafkaFlow.UnitTests/Consumer/DistributionStrategies/BytesSumDistributionStrategyTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using KafkaFlow.Consumers.DistributionStrategies;
+using KafkaFlow.UnitTests.Factories;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace KafkaFlow.UnitTests.Consumer.DistributionStrategies;
+
+[TestClass]
+public class BytesSumDistributionStrategyTests
+{
+    [TestMethod]
+    public async Task GetWorkerAsync_SingleWorkerRegistered_ReturnsThatWorkerIndepedentOfPartitionKey()
+    {
+        // Arrange
+        var expectedWorkerId = 0;
+        var workers = WorkerFactory.CreateWorkers(1);
+
+        var target = new BytesSumDistributionStrategy();
+        target.Initialize(workers);
+
+        // Act
+        var worker = await target.GetWorkerAsync(
+            new WorkerDistributionContext(null, null, 100, null, CancellationToken.None));
+
+        // Assert
+        worker.Id.Should().Be(expectedWorkerId);
+    }
+
+    [TestMethod]
+    public async Task GetWorkerAsync_MessageKeyNull_ReturnsFirstWorker()
+    {
+        // Arrange
+        var workers = WorkerFactory.CreateWorkers(10);
+
+        var target = new BytesSumDistributionStrategy();
+        target.Initialize(workers);
+
+        // Act
+        var worker = await target.GetWorkerAsync(
+            new WorkerDistributionContext(null, null, 100, null, CancellationToken.None));
+
+        // Assert
+        worker.Id.Should().Be(workers.First().Id);
+    }
+
+    [TestMethod]
+    public async Task GetWorkerAsync_CancellationRequested_ReturnsNull()
+    {
+        // Arrange
+        var workers = WorkerFactory.CreateWorkers(10);
+
+        var target = new BytesSumDistributionStrategy();
+        target.Initialize(workers);
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var worker = await target.GetWorkerAsync(
+            new WorkerDistributionContext(null, null, 0, Encoding.ASCII.GetBytes("key"), cts.Token));
+
+        // Assert
+        worker.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task GetWorkerAsync_ListOfWorkers_ReturnsExpectedWorkerForMessageKey()
+    {
+        // Arrange
+        var workerCount = 10;
+
+        // If the messageKey is changed the byteSum value needs to be updated
+        var messageKey = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("key"));
+        var byteSum = 329;
+        var expectedWorkerId = byteSum % workerCount;
+        var workers = WorkerFactory.CreateWorkers(workerCount);
+
+        var target = new BytesSumDistributionStrategy();
+        target.Initialize(workers);
+
+        // Act
+        var worker = await target.GetWorkerAsync(
+            new WorkerDistributionContext(null, null, 0, messageKey, CancellationToken.None));
+
+        // Assert
+        worker.Id.Should().Be(expectedWorkerId);
+    }
+}

--- a/tests/KafkaFlow.UnitTests/Consumer/DistributionStrategies/PartitionKeyDistributionStrategyTests.cs
+++ b/tests/KafkaFlow.UnitTests/Consumer/DistributionStrategies/PartitionKeyDistributionStrategyTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using KafkaFlow.Consumers.DistributionStrategies;
+using KafkaFlow.UnitTests.Factories;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace KafkaFlow.UnitTests.Consumer.DistributionStrategies;
+
+[TestClass]
+public class PartitionKeyDistributionStrategyTests
+{
+    [TestMethod]
+    public async Task GetWorkerAsync_SingleWorkerRegistered_ReturnsThatWorkerIndepedentOfPartitionKey()
+    {
+        // Arrange
+        var expectedWorkerId = 0;
+        var workers = WorkerFactory.CreateWorkers(1);
+
+        var target = new PartitionKeyDistributionStrategy();
+        target.Initialize(workers);
+
+        // Act
+        var worker = await target.GetWorkerAsync(
+            new WorkerDistributionContext(null, null, 100, null, CancellationToken.None));
+
+        // Assert
+        worker.Id.Should().Be(expectedWorkerId);
+    }
+
+    [TestMethod]
+    public async Task GetWorkerAsync_CancellationRequested_ReturnsNull()
+    {
+        // Arrange
+        var workers = WorkerFactory.CreateWorkers(10);
+
+        var target = new PartitionKeyDistributionStrategy();
+        target.Initialize(workers);
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var worker = await target.GetWorkerAsync(
+            new WorkerDistributionContext(null, null, 0, null, cts.Token));
+
+        // Assert
+        worker.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task GetWorkerAsync_ListOfWorkers_ReturnsExpectedWorkerForPartitionKey()
+    {
+        // Arrange
+        var workerCount = 10;
+        var partition = 5;
+        var expectedWorkerId = partition % workerCount;
+        var workers = WorkerFactory.CreateWorkers(workerCount);
+
+        var target = new PartitionKeyDistributionStrategy();
+        target.Initialize(workers);
+
+        // Act
+        var worker = await target.GetWorkerAsync(
+            new WorkerDistributionContext(null, null, partition, null, CancellationToken.None));
+
+        // Assert
+        worker.Id.Should().Be(expectedWorkerId);
+    }
+}

--- a/tests/KafkaFlow.UnitTests/Factories/WorkerFactory.cs
+++ b/tests/KafkaFlow.UnitTests/Factories/WorkerFactory.cs
@@ -1,0 +1,26 @@
+﻿using Moq;
+
+namespace KafkaFlow.UnitTests.Factories;
+
+internal static class WorkerFactory
+{
+    /// <summary>
+    /// Generate workers for testing. The Worker ID's are sequencial and zero-based.
+    /// </summary>
+    /// <param name="workerCount">Number of workers to generate</param>
+    /// <returns>A list of workers</returns>
+    public static IWorker[] CreateWorkers(int workerCount)
+    {
+        var workers = new IWorker[workerCount];
+
+        for (var i = 0; i < workerCount; i++)
+        {
+            var workerMock = new Mock<IWorker>();
+            workerMock.Setup(x => x.Id).Returns(i);
+
+            workers[i] = workerMock.Object;
+        }
+
+        return workers;
+    }
+}


### PR DESCRIPTION
# Description

The default worker distribution strategy uses the message key to distribute messages to consumers.

While the message key is the default partition strategy, it is not guaranteed the producer is using that strategy and can have implications in guaranteeing the message order when consuming messages.

This PR adds a new worker distribution strategy based on the partition key instead which better guarantees the message order.

Fixes #490 #440

## How Has This Been Tested?

Unit tests were added

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
