### PR TITLE
fix: add Microsoft.Extensions.FileProviders.Embedded package

### DIFF
--- a/src/KafkaFlow.Admin.Dashboard/KafkaFlow.Admin.Dashboard.csproj
+++ b/src/KafkaFlow.Admin.Dashboard/KafkaFlow.Admin.Dashboard.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.25" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   


### PR DESCRIPTION
# Description

The removal of `Microsoft.Extensions.FileProviders.Embedded` in [MR-486](https://github.com/Farfetch/kafkaflow/pull/486/files) caused an exception for assembly 'KafkaFlow.Admin.Dashboard' when using the [ManifestEmbeddedFileProvider](https://github.com/Farfetch/kafkaflow/blob/e2c21c0410d8f02d3292df1ad5d677c99329bae4/src/KafkaFlow.Admin.Dashboard/ApplicationBuilderExtensions.cs#L46) to get the provider.

> System.InvalidOperationException: Could not load the embedded file manifest 'Microsoft.Extensions.FileProviders.Embedded.Manifest.xml' for assembly 'KafkaFlow.Admin.Dashboard'.

This package has been added again in the current MR.

Fixes #497 

## How Has This Been Tested?

The dashboard project runs successfully without throwing any exceptions.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
