### PR TITLE
fix: add missing reference to webapi sample #502

### DIFF
--- a/samples/KafkaFlow.Sample.WebApi/KafkaFlow.Sample.WebApi.csproj
+++ b/samples/KafkaFlow.Sample.WebApi/KafkaFlow.Sample.WebApi.csproj
@@ -17,6 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\src\KafkaFlow.Admin.WebApi\KafkaFlow.Admin.WebApi.csproj" />
         <ProjectReference Include="..\..\src\KafkaFlow.Admin\KafkaFlow.Admin.csproj" />
         <ProjectReference Include="..\..\src\KafkaFlow.LogHandler.Console\KafkaFlow.LogHandler.Console.csproj" />
         <ProjectReference Include="..\..\src\KafkaFlow.Microsoft.DependencyInjection\KafkaFlow.Microsoft.DependencyInjection.csproj" />


### PR DESCRIPTION
# Description

The reference to the Admin.WebApi project was removed as part of PR #486. Because of that, the added Controllers are not picked when generating the OpenApi Specification.

Fixes #502 

## How Has This Been Tested?

Run the sample. Observe Swagger API specification.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
