### PR TITLE
fix: bump microsoft.io.recyclablememorystream from 2.3.2 to 3.0.0 #504

### DIFF
--- a/src/KafkaFlow/KafkaFlow.csproj
+++ b/src/KafkaFlow/KafkaFlow.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Confluent.Kafka" Version="2.1.1" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
         <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
# Description

The `Microsoft.IO.RecyclableMemoryStream` package was updated to Version 3.0.0.

Fixes #504

## How Has This Been Tested?

Ran the sample, with a Microsoft.IO.RecyclableMemoryStream 3.0.0 installed, and produced a message without exceptions thrown.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
