### PR TITLE
docs: Add information about new methods

### DIFF
--- a/website/docs/guides/consumers/add-consumers.md
+++ b/website/docs/guides/consumers/add-consumers.md
@@ -106,9 +106,8 @@ services.AddKafka(kafka => kafka
 ## Store Offsets Manually
 
 By default, offsets are stored after the handler and middleware execution automatically.
-This is the equivalent to configure the consumer as `WithAutoStoreOffsets()`.
 
-To control Offset storing, it's possible to configure using `WithManualStoreOffsets()` as the following example:
+To control Offset storing, it's possible to configure using `WithManualMessageCompletion()` as the following example:
 
 
 ```csharp
@@ -121,7 +120,7 @@ services.AddKafka(kafka => kafka
         .AddConsumer(consumer => consumer
             .Topic("topic-name")
             .WithGroupId("sample-group")
-            .WithManualStoreOffsets()
+            .WithManualMessageCompletion()
             ...
         )
     )

--- a/website/docs/guides/migration/from-v2-to-v3.md
+++ b/website/docs/guides/migration/from-v2-to-v3.md
@@ -244,8 +244,8 @@ For the KafkaFlow engine to adapt to the dynamic change of workers, the way the 
 
 To achieve this, a new method in the message context was provided to signal the message completion `.Complete()`. Additionally, a new property called `AutoMessageCompletion` was added to signal if KafkaFlow should signal the message as completed automatically which is the default behavior. This property is useful for scenarios where we don't want to complete the message right away, for example in Batch Consume scenarios.
 
-- Use `WithManualMessageCompletion()` instead of `WithManualStoreOffsets`.
-- Use `context.ConsumerContext.Complete()` instead of `context.ConsumerContext.StoreOffset();`.
+- Use `WithManualMessageCompletion()` instead of `WithManualStoreOffsets()`.
+- Use `context.ConsumerContext.Complete()` instead of `context.ConsumerContext.StoreOffset()`.
 
 ### 1.3 Expose Worker Events to Client Applications
 

--- a/website/docs/guides/migration/from-v2-to-v3.md
+++ b/website/docs/guides/migration/from-v2-to-v3.md
@@ -244,6 +244,9 @@ For the KafkaFlow engine to adapt to the dynamic change of workers, the way the 
 
 To achieve this, a new method in the message context was provided to signal the message completion `.Complete()`. Additionally, a new property called `AutoMessageCompletion` was added to signal if KafkaFlow should signal the message as completed automatically which is the default behavior. This property is useful for scenarios where we don't want to complete the message right away, for example in Batch Consume scenarios.
 
+- Use `WithManualMessageCompletion()` instead of `WithManualStoreOffsets`.
+- Use `context.ConsumerContext.Complete()` instead of `context.ConsumerContext.StoreOffset();`.
+
 ### 1.3 Expose Worker Events to Client Applications
 
 > Related Issues: [#427](https://github.com/Farfetch/kafkaflow/issues/427)


### PR DESCRIPTION
# Description

Changes only in the documentation
Added information about new methods that exists in V3 nuget, but not existed before and which old methods they are replacement.