### PR TITLE
fix: producing null messages

### DIFF
--- a/src/KafkaFlow/Middlewares/Serializer/SerializerProducerMiddleware.cs
+++ b/src/KafkaFlow/Middlewares/Serializer/SerializerProducerMiddleware.cs
@@ -38,7 +38,7 @@ public class SerializerProducerMiddleware : IMessageMiddleware
     {
         await _typeResolver.OnProduceAsync(context);
 
-        byte[] messageValue;
+        byte[] messageValue = null;
 
         using (var buffer = s_memoryStreamManager.GetStream())
         {
@@ -48,8 +48,10 @@ public class SerializerProducerMiddleware : IMessageMiddleware
                     buffer,
                     new SerializerContext(context.ProducerContext.Topic))
                 .ConfigureAwait(false);
-
-            messageValue = buffer.ToArray();
+            if (buffer.Length > 0)
+            {
+                messageValue = buffer.ToArray();
+            }
         }
 
         await next(context.SetMessage(context.Message.Key, messageValue)).ConfigureAwait(false);

--- a/tests/KafkaFlow.IntegrationTests/Core/Handlers/NullMessageHandler.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/Handlers/NullMessageHandler.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+
+namespace KafkaFlow.IntegrationTests.Core.Handlers;
+
+internal class NullMessageHandler : IMessageHandler<byte[]> 
+{
+    public Task Handle(IMessageContext context, byte[] message)
+    {
+        MessageStorage.AddNullMessage(message);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/KafkaFlow.IntegrationTests/Core/Producers/NullProducer.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/Producers/NullProducer.cs
@@ -1,0 +1,6 @@
+namespace KafkaFlow.IntegrationTests.Core.Producers;
+
+public class NullProducer
+{
+    
+}

--- a/tests/KafkaFlow.IntegrationTests/ProducerTest.cs
+++ b/tests/KafkaFlow.IntegrationTests/ProducerTest.cs
@@ -36,4 +36,18 @@ public class ProducerTest
         // Assert
         await MessageStorage.AssertMessageAsync(message);
     }
+    
+    [TestMethod]
+    public async Task ProduceNullMessageTest()
+    {
+        // Arrange
+        var producer = _provider.GetRequiredService<IMessageProducer<NullProducer>>();
+        var key = Guid.NewGuid().ToString();
+
+        // Act
+        await producer.ProduceAsync(key, null);
+
+        // Assert
+        await MessageStorage.AssertNullMessageAsync();
+    }
 }

--- a/tests/KafkaFlow.UnitTests/Serializers/SerializerProducerMiddlewareTests.cs
+++ b/tests/KafkaFlow.UnitTests/Serializers/SerializerProducerMiddlewareTests.cs
@@ -84,6 +84,60 @@ public class SerializerProducerMiddlewareTests
         _serializerMock.VerifyAll();
         _typeResolverMock.VerifyAll();
     }
+    
+    [TestMethod]
+    public async Task Invoke_NullMessage_Serialize()
+    {
+        // Arrange
+        byte[] rawMessage = null;
+        var key = new object();
+        var deserializedMessage = new Message(key, new TestMessage());
+        IMessageContext resultContext = null;
+        var producerContext = new Mock<IProducerContext>();
+        producerContext.SetupGet(x => x.Topic).Returns("test-topic");
+
+        var transformedContextMock = new Mock<IMessageContext>();
+
+        _contextMock
+            .SetupGet(x => x.Message)
+            .Returns(deserializedMessage);
+
+        _typeResolverMock.Setup(x => x.OnProduceAsync(_contextMock.Object));
+
+        _serializerMock
+            .Setup(
+                x => x.SerializeAsync(
+                    deserializedMessage.Value,
+                    It.IsAny<Stream>(),
+                    It.IsAny<ISerializerContext>()))
+            .Callback((object _, Stream stream, ISerializerContext _) => stream.WriteAsync(rawMessage));
+
+        _contextMock
+            .Setup(x => x.SetMessage(key, null))
+            .Returns(transformedContextMock.Object);
+
+        _contextMock
+            .SetupGet(x => x.ProducerContext)
+            .Returns(producerContext.Object);
+
+        // Act
+        await _target.Invoke(
+            _contextMock.Object,
+            ctx =>
+            {
+                resultContext = ctx;
+                return Task.CompletedTask;
+            });
+
+        // Assert
+        resultContext.Should().NotBeNull();
+        resultContext.Should().Be(transformedContextMock.Object);
+        resultContext.Message.Value.Should().BeNull();
+        _contextMock.VerifyAll();
+        _serializerMock.VerifyAll();
+        _typeResolverMock.VerifyAll();
+    }
+    
 
     private class TestMessage
     {


### PR DESCRIPTION
# Description

Producing null records. This is needed to produce tombstone records for an upsert-kafka connector. https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/upsert-kafka/ 

Fixes [#516](https://github.com/Farfetch/kafkaflow/issues/516)

## How Has This Been Tested?
- Added Invoke_NullMessage_Serialize unit test
- Added ProduceNullMessageTest integration test
- Performed end to end test using upsert-kafka connector source and Apache iceberg sink. 

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
