### PR TITLE
fix: remove duplicate DI registration of IClusterManagerAccessor

### DIFF
--- a/src/KafkaFlow/Configuration/KafkaConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/KafkaConfigurationBuilder.cs
@@ -49,7 +49,6 @@ internal class KafkaConfigurationBuilder : IKafkaConfigurationBuilder
             .AddSingleton<IClusterManagerAccessor, ClusterManagerAccessor>()
             .AddScoped<ConsumerMiddlewareContext>()
             .AddScoped<IConsumerMiddlewareContext>(r => r.Resolve<ConsumerMiddlewareContext>())
-            .AddSingleton<IClusterManagerAccessor, ClusterManagerAccessor>()
             .AddSingleton(
                 r =>
                 {


### PR DESCRIPTION
# Description

`IClusterManagerAccessor` is already registered as a singleton a few lines above.

Looks like this line was accidentally duplicated in https://github.com/Farfetch/kafkaflow/commit/3f996b61bd2850fbe7cd5893bae54b78521ae74c#diff-ad7219aa5db9d536244342b218fd6ef245e685445e173b747ef99513d520dbc4R52

The duplicate registration breaks our Ninject DI implementation:
```
Ninject.ActivationException : Error activating IConsumerManagerFactory
More than one matching bindings are available.
Matching bindings:
  1) binding from IConsumerManagerFactory to constant value
  2) binding from IConsumerManagerFactory to constant value
Activation path:
  1) Request for IConsumerManagerFactory

Suggestions:
  1) Ensure that you have defined a binding for IConsumerManagerFactory only once.
```

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
