### PR TITLE
docs: fix typo in middlewares.md - InvalidOperationException incorrectly spelled with lowercase 'o'

### DIFF
--- a/website/docs/guides/middlewares/middlewares.md
+++ b/website/docs/guides/middlewares/middlewares.md
@@ -144,7 +144,7 @@ public class JsonDeserializeMiddleware : IMessageMiddleware
     public Task Invoke(IMessageContext context, MiddlewareDelegate next)
     {
         if(!(context.Message is byte[] rawMessage))
-            throw new InvalidoperationException();
+            throw new InvalidOperationException();
 
         var type = Type.GetType(context.Headers.GetString("Message-Type"));
 


### PR DESCRIPTION
# Description

Hi, I discovered your library recently and was going through the docs and copying examples, and found a small typo which makes the sample code not compile.

## How Has This Been Tested?

Copied the [correct name](https://learn.microsoft.com/en-us/dotnet/api/system.invalidoperationexception) from Visual Studio.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
