### PR TITLE
fix: does not serialize exception in ProduceTelemetry

### DIFF
--- a/src/KafkaFlow.Abstractions/ILogHandler.cs
+++ b/src/KafkaFlow.Abstractions/ILogHandler.cs
@@ -23,6 +23,14 @@ public interface ILogHandler
     void Warning(string message, object data);
 
     /// <summary>
+    /// Writes a warning log entry
+    /// </summary>
+    /// <param name="message">Warning message</param>
+    /// <param name="ex">Exception thrown</param>
+    /// <param name="data">Additional data related to the warning log</param>
+    void Warning(string message, Exception ex, object data);
+
+    /// <summary>
     /// Writes a info log entry
     /// </summary>
     /// <param name="message">Info message</param>

--- a/src/KafkaFlow.Abstractions/NullLogHandler.cs
+++ b/src/KafkaFlow.Abstractions/NullLogHandler.cs
@@ -20,6 +20,12 @@ public class NullLogHandler : ILogHandler
     }
 
     /// <inheritdoc />
+    public void Warning(string message, Exception ex, object data)
+    {
+        // Do nothing
+    }
+
+    /// <inheritdoc />
     public void Info(string message, object data)
     {
         // Do nothing

--- a/src/KafkaFlow.Admin/TelemetryScheduler.cs
+++ b/src/KafkaFlow.Admin/TelemetryScheduler.cs
@@ -96,7 +96,7 @@ internal class TelemetryScheduler : ITelemetryScheduler
         }
         catch (Exception e)
         {
-            _logHandler.Warning("Error producing telemetry data", new { Exception = e });
+            _logHandler.Warning("Error producing telemetry data", e, null);
         }
     }
 }

--- a/src/KafkaFlow.LogHandler.Console/ConsoleLogHandler.cs
+++ b/src/KafkaFlow.LogHandler.Console/ConsoleLogHandler.cs
@@ -24,6 +24,21 @@ internal class ConsoleLogHandler : ILogHandler
         $"\nKafkaFlow: {message} | Data: {JsonSerializer.Serialize(data)}",
         ConsoleColor.Yellow);
 
+    public void Warning(string message, Exception ex, object data)
+    {
+        var serializedException = JsonSerializer.Serialize(
+         new
+         {
+             Type = ex.GetType().FullName,
+             ex.Message,
+             ex.StackTrace,
+         });
+
+        Print(
+            $"\nKafkaFlow: {message} | Data: {JsonSerializer.Serialize(data)} | Exception: {serializedException}",
+            ConsoleColor.Yellow);
+    }
+
     public void Info(string message, object data) => Print(
         $"\nKafkaFlow: {message} | Data: {JsonSerializer.Serialize(data)}",
         ConsoleColor.Green);

--- a/src/KafkaFlow.LogHandler.Microsoft/MicrosoftLogHandler.cs
+++ b/src/KafkaFlow.LogHandler.Microsoft/MicrosoftLogHandler.cs
@@ -6,6 +6,8 @@ namespace KafkaFlow;
 
 internal class MicrosoftLogHandler : ILogHandler
 {
+    private const string SerializationErrorMessage = "Log data serialization error.";
+
     private readonly ILogger _logger;
 
     public MicrosoftLogHandler(ILoggerFactory loggerFactory)
@@ -15,21 +17,47 @@ internal class MicrosoftLogHandler : ILogHandler
 
     public void Error(string message, Exception ex, object data)
     {
-        _logger.LogError(ex, "{Message} | Data: {Data}", message, JsonSerializer.Serialize(data));
+        _logger.LogError(ex, "{Message} | Data: {Data}", message, SerializeData(data));
     }
 
     public void Warning(string message, object data)
     {
-        _logger.LogWarning("{Message} | Data: {Data}", message, JsonSerializer.Serialize(data));
+        _logger.LogWarning("{Message} | Data: {Data}", message, SerializeData(data));
+    }
+
+    public void Warning(string message, Exception ex, object data)
+    {
+        _logger.LogWarning(ex, "{Message} | Data: {Data}", message, SerializeData(data));
     }
 
     public void Info(string message, object data)
     {
-        _logger.LogInformation("{Message} | Data: {Data}", message, JsonSerializer.Serialize(data));
+        _logger.LogInformation("{Message} | Data: {Data}", message, SerializeData(data));
     }
 
     public void Verbose(string message, object data)
     {
-        _logger.LogDebug("{Message} | Data: {Data}", message, JsonSerializer.Serialize(data));
+        _logger.LogDebug("{Message} | Data: {Data}", message, SerializeData(data));
+    }
+
+    private string SerializeData(object data)
+    {
+        if (data is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Serialize(data);
+        }
+        catch(Exception ex)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                Error = SerializationErrorMessage,
+                Exception = $"Message: {ex.Message}, Trace: {ex.StackTrace}",
+            });
+        }
     }
 }

--- a/tests/KafkaFlow.IntegrationTests/Core/TraceLogHandler.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/TraceLogHandler.cs
@@ -29,6 +29,18 @@ internal class TraceLogHandler : ILogHandler
                 }));
     }
 
+    public void Warning(string message, Exception ex, object data)
+    {
+        Trace.TraceWarning(
+            JsonSerializer.Serialize(
+                new
+                {
+                    Message = message,
+                    Exception = ex,
+                    Data = data,
+                }));
+    }
+
     public void Info(string message, object data)
     {
         Trace.TraceInformation(

--- a/tests/KafkaFlow.UnitTests/LogHandlers/MicrosoftLogHandlerTests.cs
+++ b/tests/KafkaFlow.UnitTests/LogHandlers/MicrosoftLogHandlerTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System;
+using System.Linq;
 
 namespace KafkaFlow.UnitTests.LogHandlers;
 
@@ -20,5 +22,32 @@ public class MicrosoftLogHandlerTests
 
         // Assert
         loggerFactoryMock.Verify(x => x.CreateLogger("KafkaFlow"), Times.Once);
+    }
+
+    [TestMethod]
+    public void LogWarning_WithNotSerializableData_DoesNotSerializeObject()
+    {
+        // Arrange
+        var expectedMessage = "Any message";
+        var expectedSerializationErrorMessage = "Log data serialization error.";
+        var loggerMock = new Mock<ILogger>();
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        
+        loggerFactoryMock
+            .Setup(x => x.CreateLogger("KafkaFlow"))
+            .Returns(loggerMock.Object);
+
+        var handler = new MicrosoftLogHandler(loggerFactoryMock.Object);
+
+        // Act
+        handler.Warning(expectedMessage, new
+        {
+            In = new IntPtr(1)
+        });
+
+        // Assert
+        Assert.AreEqual(1, loggerMock.Invocations.Count);
+        Assert.IsTrue(loggerMock.Invocations[0].Arguments.Any(x => x.ToString().Contains(expectedMessage)));
+        Assert.IsTrue(loggerMock.Invocations[0].Arguments.Any(x => x.ToString().Contains(expectedSerializationErrorMessage)));
     }
 }


### PR DESCRIPTION
# Description

Avoid rethrow exception when there are errors on serialize exception data

Closes #537 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
