### PR TITLE
fix: fix to ignore header max length

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,5 +1,6 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
   rules: {
     'body-max-line-length': [0, 'always'],
   }  


### PR DESCRIPTION
# Description

Add ignore to header max length of the dependabot and fix build pipeline

Fixes # (issue)

## How Has This Been Tested?

Run the pipeline and check if now passes

## Checklist

-   [X ] My code follows the style guidelines of this project
-   [ X] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
