### PR TITLE
feat: allow use of cluster defined values for topic creation

### DIFF
--- a/src/KafkaFlow.Abstractions/Configuration/IClusterConfigurationBuilder.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/IClusterConfigurationBuilder.cs
@@ -75,11 +75,11 @@ public interface IClusterConfigurationBuilder
     /// Adds a Topic to the Cluster
     /// </summary>
     /// <param name="topicName">The topic name</param>
-    /// <param name="numberOfPartitions">The number of Topic partitions</param>
-    /// <param name="replicationFactor">The Topic replication factor</param>
+    /// <param name="numberOfPartitions">The number of Topic partitions. Default is to use the cluster-defined partitions.</param>
+    /// <param name="replicationFactor">The Topic replication factor. Default is to use the cluster-defined replication factor.</param>
     /// <returns></returns>
     IClusterConfigurationBuilder CreateTopicIfNotExists(
         string topicName,
-        int numberOfPartitions,
-        short replicationFactor);
+        int numberOfPartitions = -1,
+        short replicationFactor = -1);
 }

--- a/src/KafkaFlow/Configuration/ClusterConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ClusterConfigurationBuilder.cs
@@ -110,8 +110,8 @@ internal class ClusterConfigurationBuilder : IClusterConfigurationBuilder
 
     public IClusterConfigurationBuilder CreateTopicIfNotExists(
         string topicName,
-        int numberOfPartitions,
-        short replicationFactor)
+        int numberOfPartitions = -1,
+        short replicationFactor = -1)
     {
         _topicsToCreateIfNotExist.Add(new TopicConfiguration(topicName, numberOfPartitions, replicationFactor));
         return this;

--- a/tests/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
@@ -42,6 +42,7 @@ internal static class Bootstrapper
     private const string ProtobufGzipTopicName2 = "test-protobuf-gzip-2";
     private const string AvroTopicName = "test-avro";
     private const string NullTopicName = "test-null";
+    private const string DefaultParamsTopicName = "test-default-params";
 
     private static readonly Lazy<IServiceProvider> s_lazyProvider = new(SetupProvider);
 
@@ -202,6 +203,7 @@ internal static class Bootstrapper
                         .CreateTopicIfNotExists(ProtobufGzipTopicName, 2, 1)
                         .CreateTopicIfNotExists(ProtobufGzipTopicName2, 2, 1)
                         .CreateTopicIfNotExists(NullTopicName, 1, 1)
+                        .CreateTopicIfNotExists(DefaultParamsTopicName)
                         .AddConsumer(
                             consumer => consumer
                                 .Topic(ProtobufTopicName)


### PR DESCRIPTION
# Description

If passing `-1` for `NumPartitions` or `ReplicationFactor` when creating topics, the creation will use the cluster-default values for these values. This change allows for defaulting to using cluster values, and over-riding them if required. This reduces a lot of boilerplate code when setting up a cluster in code.

## How Has This Been Tested?

Added integration tests to test this against a Kafka instance.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
