### PR TITLE
feat: add support for csharp namespace in protobuf schemas

### DIFF
--- a/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/ConfluentProtobufTypeNameResolver.cs
+++ b/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/ConfluentProtobufTypeNameResolver.cs
@@ -20,7 +20,13 @@ internal class ConfluentProtobufTypeNameResolver : ISchemaRegistryTypeNameResolv
         var schemaString = (await _client.GetSchemaAsync(id, "serialized")).SchemaString;
 
         var protoFields = FileDescriptorProto.Parser.ParseFrom(ByteString.FromBase64(schemaString));
-
-        return $"{protoFields.Package}.{protoFields.MessageType.FirstOrDefault()?.Name}";
+        var messageType = protoFields.MessageType.FirstOrDefault()?.Name;
+        var ns = protoFields.Options?.HasCsharpNamespace == true
+            ? protoFields.Options.CsharpNamespace
+            : protoFields.Package;
+        return BuildTypeName(messageType, ns);
     }
+
+    private static string BuildTypeName(string messageType, string ns)
+        => string.IsNullOrEmpty(ns) ? messageType ?? string.Empty : $"{ns}.{messageType}";
 }


### PR DESCRIPTION
# Description

This pull request enhances the `ConfluentProtobufTypeNameResolver` to respect the `csharp_namespace` option specified in protobuf files when resolving type names from the Confluent Schema Registry. Previously, the resolver did not consider this option and only used the protobuf package to construct the resolved name. This change ensures better compatibility with C# namespaces and avoids potential conflicts in projects using custom namespaces.

Fixes #229 

## How Has This Been Tested?

- **Unit Tests**: Added unit tests to check whether the resolver correctly handles protobuf files with and without the `csharp_namespace` option.
- **Manual Testing**: Manually tested the changes in a .NET application to ensure that the resolved names are correctly used in the context of message serialization and deserialization.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
