### PR TITLE
fix: use ConfigureAwait(false) on all awaits

### DIFF
--- a/src/KafkaFlow/Batching/BatchConsumeMiddleware.cs
+++ b/src/KafkaFlow/Batching/BatchConsumeMiddleware.cs
@@ -38,7 +38,7 @@ internal class BatchConsumeMiddleware : IMessageMiddleware, IDisposable
 
     public async Task Invoke(IMessageContext context, MiddlewareDelegate next)
     {
-        await _dispatchSemaphore.WaitAsync();
+        await _dispatchSemaphore.WaitAsync().ConfigureAwait(false);
 
         try
         {
@@ -59,7 +59,7 @@ internal class BatchConsumeMiddleware : IMessageMiddleware, IDisposable
 
         if (_batch.Count >= _batchSize)
         {
-            await this.TriggerDispatchAndWaitAsync();
+            await this.TriggerDispatchAndWaitAsync().ConfigureAwait(false);
         }
     }
 
@@ -72,11 +72,11 @@ internal class BatchConsumeMiddleware : IMessageMiddleware, IDisposable
 
     private async Task TriggerDispatchAndWaitAsync()
     {
-        await _dispatchSemaphore.WaitAsync();
+        await _dispatchSemaphore.WaitAsync().ConfigureAwait(false);
         _dispatchTokenSource?.Cancel();
         _dispatchSemaphore.Release();
 
-        await (_dispatchTask ?? Task.CompletedTask);
+        await (_dispatchTask ?? Task.CompletedTask).ConfigureAwait(false);
     }
 
     private void ScheduleExecution(IMessageContext context, MiddlewareDelegate next)
@@ -92,7 +92,7 @@ internal class BatchConsumeMiddleware : IMessageMiddleware, IDisposable
 
     private async Task DispatchAsync(IMessageContext context, MiddlewareDelegate next)
     {
-        await _dispatchSemaphore.WaitAsync();
+        await _dispatchSemaphore.WaitAsync().ConfigureAwait(false);
 
         _dispatchTokenSource.Dispose();
         _dispatchTokenSource = null;

--- a/src/KafkaFlow/Clusters/ClusterManager.cs
+++ b/src/KafkaFlow/Clusters/ClusterManager.cs
@@ -85,7 +85,7 @@ internal class ClusterManager : IClusterManager, IDisposable
 
         foreach (var name in topicsName)
         {
-            topicsMetadata.Add((name, await this.GetTopicMetadataAsync(name)));
+            topicsMetadata.Add((name, await this.GetTopicMetadataAsync(name).ConfigureAwait(false)));
         }
 
         var topics =
@@ -98,7 +98,7 @@ internal class ClusterManager : IClusterManager, IDisposable
                 .ToList();
 
         var result = await _lazyAdminClient.Value.ListConsumerGroupOffsetsAsync(
-            new[] { new ConsumerGroupTopicPartitions(consumerGroup, topics) });
+            new[] { new ConsumerGroupTopicPartitions(consumerGroup, topics) }).ConfigureAwait(false);
 
         if (!result.Any())
         {
@@ -125,7 +125,7 @@ internal class ClusterManager : IClusterManager, IDisposable
                     })
                 .ToArray();
 
-            await _lazyAdminClient.Value.CreateTopicsAsync(topics);
+            await _lazyAdminClient.Value.CreateTopicsAsync(topics).ConfigureAwait(false);
         }
         catch (CreateTopicsException exception)
         {

--- a/src/KafkaFlow/Consumers/Consumer.cs
+++ b/src/KafkaFlow/Consumers/Consumer.cs
@@ -163,7 +163,7 @@ internal class Consumer : IConsumer
             try
             {
                 this.EnsureConsumer();
-                await _flowManager.BlockHeartbeat(cancellationToken);
+                await _flowManager.BlockHeartbeat(cancellationToken).ConfigureAwait(false);
                 return _consumer.Consume(cancellationToken);
             }
             catch (OperationCanceledException)
@@ -176,7 +176,7 @@ internal class Consumer : IConsumer
                     "Max Poll Interval Exceeded",
                     new { this.Configuration.ConsumerName });
 
-                await _maxPollIntervalExceeded.FireAsync();
+                await _maxPollIntervalExceeded.FireAsync().ConfigureAwait(false);
             }
             catch (KafkaException ex) when (ex.Error.IsFatal)
             {
@@ -187,7 +187,7 @@ internal class Consumer : IConsumer
 
                 this.InvalidateConsumer();
 
-                await Task.Delay(5000, cancellationToken);
+                await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/KafkaFlow/Consumers/ConsumerManager.cs
+++ b/src/KafkaFlow/Consumers/ConsumerManager.cs
@@ -70,14 +70,14 @@ internal class ConsumerManager : IConsumerManager
 
     private async Task EvaluateWorkersCountAsync()
     {
-        var newWorkersCount = await this.CalculateWorkersCount(this.Consumer.Assignment);
+        var newWorkersCount = await this.CalculateWorkersCount(this.Consumer.Assignment).ConfigureAwait(false);
 
         if (newWorkersCount == this.WorkerPool.CurrentWorkersCount)
         {
             return;
         }
 
-        await this.ChangeWorkersCountAsync(newWorkersCount);
+        await this.ChangeWorkersCountAsync(newWorkersCount).ConfigureAwait(false);
     }
 
     private async Task ChangeWorkersCountAsync(int workersCount)
@@ -86,10 +86,10 @@ internal class ConsumerManager : IConsumerManager
         {
             this.StopEvaluateWorkerCountTimer();
 
-            await this.Feeder.StopAsync();
-            await this.WorkerPool.StopAsync();
+            await this.Feeder.StopAsync().ConfigureAwait(false);
+            await this.WorkerPool.StopAsync().ConfigureAwait(false);
 
-            await this.WorkerPool.StartAsync(this.Consumer.Assignment, workersCount);
+            await this.WorkerPool.StartAsync(this.Consumer.Assignment, workersCount).ConfigureAwait(false);
             this.Feeder.Start();
 
             this.StartEvaluateWorkerCountTimer();
@@ -155,7 +155,8 @@ internal class ConsumerManager : IConsumerManager
                                     .Select(x => x.Partition.Value)
                                     .ToList()))
                         .ToList()),
-                _dependencyResolver);
+                _dependencyResolver)
+                .ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/src/KafkaFlow/Consumers/WorkerPoolFeeder.cs
+++ b/src/KafkaFlow/Consumers/WorkerPoolFeeder.cs
@@ -72,6 +72,6 @@ internal class WorkerPoolFeeder : IWorkerPoolFeeder
             _stopTokenSource.Dispose();
         }
 
-        await (_feederTask ?? Task.CompletedTask);
+        await (_feederTask ?? Task.CompletedTask).ConfigureAwait(false);
     }
 }

--- a/src/KafkaFlow/Consumers/WorkersBalancers/ConsumerLagWorkerBalancer.cs
+++ b/src/KafkaFlow/Consumers/WorkersBalancers/ConsumerLagWorkerBalancer.cs
@@ -41,7 +41,7 @@ internal class ConsumerLagWorkerBalancer
 
     public async Task<int> GetWorkersCountAsync(WorkersCountContext context)
     {
-        var workers = await this.CalculateAsync(context);
+        var workers = await this.CalculateAsync(context).ConfigureAwait(false);
 
         _logHandler.Info(
             "New workers count calculated",
@@ -97,13 +97,14 @@ internal class ConsumerLagWorkerBalancer
                 return DefaultWorkersCount;
             }
 
-            var topicsMetadata = await this.GetTopicsMetadataAsync(context);
+            var topicsMetadata = await this.GetTopicsMetadataAsync(context).ConfigureAwait(false);
 
             var lastOffsets = this.GetPartitionsLastOffset(context.ConsumerName, topicsMetadata);
 
             var partitionsOffset = await _clusterManager.GetConsumerGroupOffsetsAsync(
                 context.ConsumerGroupId,
-                context.AssignedTopicsPartitions.Select(t => t.Name));
+                context.AssignedTopicsPartitions.Select(t => t.Name))
+                .ConfigureAwait(false);
 
             var partitionsLag = CalculatePartitionsLag(lastOffsets, partitionsOffset);
             var instanceLag = CalculateMyPartitionsLag(context, partitionsLag);
@@ -156,7 +157,7 @@ internal class ConsumerLagWorkerBalancer
 
         foreach (var topic in context.AssignedTopicsPartitions)
         {
-            topicsMetadata.Add((topic.Name, await _clusterManager.GetTopicMetadataAsync(topic.Name)));
+            topicsMetadata.Add((topic.Name, await _clusterManager.GetTopicMetadataAsync(topic.Name).ConfigureAwait(false)));
         }
 
         return topicsMetadata;

--- a/src/KafkaFlow/Extensions/ChannelExtensions.cs
+++ b/src/KafkaFlow/Extensions/ChannelExtensions.cs
@@ -11,7 +11,7 @@ internal static class ChannelExtensions
         this ChannelReader<T> reader,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        while (await reader.WaitToReadAsync(cancellationToken))
+        while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
             while (reader.TryRead(out var item))
             {

--- a/src/KafkaFlow/Extensions/TaskExtensions.cs
+++ b/src/KafkaFlow/Extensions/TaskExtensions.cs
@@ -21,7 +21,7 @@ internal static class TaskExtensions
             return;
         }
 
-        await Task.WhenAny(task, tcs.Task);
+        await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
 
         void TrySetResult()
         {

--- a/src/KafkaFlow/KafkaBus.cs
+++ b/src/KafkaFlow/KafkaBus.cs
@@ -48,7 +48,7 @@ internal class KafkaBus : IKafkaBus
 
         foreach (var cluster in _configuration.Clusters)
         {
-            await this.CreateMissingClusterTopics(cluster);
+            await this.CreateMissingClusterTopics(cluster).ConfigureAwait(false);
 
             foreach (var consumerConfiguration in cluster.Consumers)
             {
@@ -101,6 +101,7 @@ internal class KafkaBus : IKafkaBus
         }
 
         await _clusterManagerAccessor[cluster.Name].CreateIfNotExistsAsync(
-            cluster.TopicsToCreateIfNotExist);
+            cluster.TopicsToCreateIfNotExist)
+            .ConfigureAwait(false);
     }
 }

--- a/src/KafkaFlow/Middlewares/ConsumerThrottling/ConsumerThrottlingThreshold.cs
+++ b/src/KafkaFlow/Middlewares/ConsumerThrottling/ConsumerThrottlingThreshold.cs
@@ -21,7 +21,7 @@ internal class ConsumerThrottlingThreshold : IConsumerThrottlingThreshold
             return false;
         }
 
-        await _action.ExecuteAsync();
+        await _action.ExecuteAsync().ConfigureAwait(false);
 
         return true;
     }

--- a/src/KafkaFlow/Middlewares/Serializer/DeserializerConsumerMiddleware.cs
+++ b/src/KafkaFlow/Middlewares/Serializer/DeserializerConsumerMiddleware.cs
@@ -53,7 +53,7 @@ public class DeserializerConsumerMiddleware : IMessageMiddleware
             return;
         }
 
-        var messageType = await _typeResolver.OnConsumeAsync(context);
+        var messageType = await _typeResolver.OnConsumeAsync(context).ConfigureAwait(false);
 
         if (messageType is null)
         {

--- a/src/KafkaFlow/Middlewares/Serializer/SerializerProducerMiddleware.cs
+++ b/src/KafkaFlow/Middlewares/Serializer/SerializerProducerMiddleware.cs
@@ -37,7 +37,7 @@ public class SerializerProducerMiddleware : IMessageMiddleware
     /// <returns></returns>
     public async Task Invoke(IMessageContext context, MiddlewareDelegate next)
     {
-        await _typeResolver.OnProduceAsync(context);
+        await _typeResolver.OnProduceAsync(context).ConfigureAwait(false);
 
         byte[] messageValue = Array.Empty<byte>();
 

--- a/src/KafkaFlow/Producers/MessageProducer.cs
+++ b/src/KafkaFlow/Producers/MessageProducer.cs
@@ -50,7 +50,7 @@ internal class MessageProducer : IMessageProducer, IDisposable
             headers,
             messageScope.Resolver);
 
-        await _globalEvents.FireMessageProduceStartedAsync(new MessageEventContext(messageContext));
+        await _globalEvents.FireMessageProduceStartedAsync(new MessageEventContext(messageContext)).ConfigureAwait(false);
 
         try
         {
@@ -65,11 +65,11 @@ internal class MessageProducer : IMessageProducer, IDisposable
                     })
                 .ConfigureAwait(false);
 
-            await _globalEvents.FireMessageProduceCompletedAsync(new MessageEventContext(messageContext));
+            await _globalEvents.FireMessageProduceCompletedAsync(new MessageEventContext(messageContext)).ConfigureAwait(false);
         }
         catch (Exception e)
         {
-            await _globalEvents.FireMessageProduceErrorAsync(new MessageErrorEventContext(messageContext, e));
+            await _globalEvents.FireMessageProduceErrorAsync(new MessageErrorEventContext(messageContext, e)).ConfigureAwait(false);
             throw;
         }
 
@@ -311,7 +311,7 @@ internal class MessageProducer : IMessageProducer, IDisposable
         }
         catch (ProduceException<byte[], byte[]> e)
         {
-            await _globalEvents.FireMessageProduceErrorAsync(new MessageErrorEventContext(context, e));
+            await _globalEvents.FireMessageProduceErrorAsync(new MessageErrorEventContext(context, e)).ConfigureAwait(false);
 
             if (e.Error.IsFatal)
             {


### PR DESCRIPTION
# Description

Use `ConfigureAwait(false)` on all awaits. This was already present on some awaits in KafkaFlow, but applied inconsistently.

This allows awaits to continue without forcing the callback to be invoked on the original context or scheduler. This can improve performance and help prevent deadlocks when used in environments with a `SynchronizationContext` such as ASP .NET Framework or UI applications.

This seems to be best practice in libraries (even if it unfortunately makes async code less simple / clean):
- https://devblogs.microsoft.com/dotnet/configureawait-faq/
- https://blog.stephencleary.com/2017/03/aspnetcore-synchronization-context.html
- https://blog.stephencleary.com/2023/11/configureawait-in-net-8.html

Fixes #563

## How Has This Been Tested?

We stopped experiencing stalls in Kafka message consumption in ASP .NET Framework after making this change.

All unit / integration tests pass.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
