### PR TITLE
Extend TopicConfiguration to support dynamic configuration when creating topics

### DIFF
--- a/src/KafkaFlow.Abstractions/Configuration/IClusterConfigurationBuilder.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/IClusterConfigurationBuilder.cs
@@ -77,9 +77,13 @@ public interface IClusterConfigurationBuilder
     /// <param name="topicName">The topic name</param>
     /// <param name="numberOfPartitions">The number of Topic partitions. Default is to use the cluster-defined partitions.</param>
     /// <param name="replicationFactor">The Topic replication factor. Default is to use the cluster-defined replication factor.</param>
+    /// <param name="configs">The configuration to use to create the new topic</param>
+    /// <param name="replicasAssignments">A map from partition id to replica ids</param>
     /// <returns></returns>
     IClusterConfigurationBuilder CreateTopicIfNotExists(
         string topicName,
         int numberOfPartitions = -1,
-        short replicationFactor = -1);
+        short replicationFactor = -1,
+        IDictionary<string, string> configs = null,
+        IDictionary<int, IEnumerable<int>> replicasAssignments = null);
 }

--- a/src/KafkaFlow/Clusters/ClusterManager.cs
+++ b/src/KafkaFlow/Clusters/ClusterManager.cs
@@ -122,6 +122,8 @@ internal class ClusterManager : IClusterManager, IDisposable
                         Name = topicConfiguration.Name,
                         ReplicationFactor = topicConfiguration.Replicas,
                         NumPartitions = topicConfiguration.Partitions,
+                        Configs = topicConfiguration.Configs.ToDictionary(x => x.Key, x => x.Value),
+                        ReplicasAssignments = topicConfiguration.ReplicasAssignments.ToDictionary(x => x.Key, x => x.Value.ToList()),
                     })
                 .ToArray();
 

--- a/src/KafkaFlow/Configuration/ClusterConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ClusterConfigurationBuilder.cs
@@ -111,9 +111,11 @@ internal class ClusterConfigurationBuilder : IClusterConfigurationBuilder
     public IClusterConfigurationBuilder CreateTopicIfNotExists(
         string topicName,
         int numberOfPartitions = -1,
-        short replicationFactor = -1)
+        short replicationFactor = -1,
+        IDictionary<string, string> configs = null,
+        IDictionary<int, IEnumerable<int>> replicasAssignments = null)
     {
-        _topicsToCreateIfNotExist.Add(new TopicConfiguration(topicName, numberOfPartitions, replicationFactor));
+        _topicsToCreateIfNotExist.Add(new TopicConfiguration(topicName, numberOfPartitions, replicationFactor, configs, replicasAssignments));
         return this;
     }
 }

--- a/src/KafkaFlow/Configuration/TopicConfiguration.cs
+++ b/src/KafkaFlow/Configuration/TopicConfiguration.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
 namespace KafkaFlow.Configuration;
 
 /// <summary>
@@ -5,17 +9,26 @@ namespace KafkaFlow.Configuration;
 /// </summary>
 public class TopicConfiguration
 {
+    private static readonly IReadOnlyDictionary<string, string> s_emptyConfigs = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+    private static readonly IReadOnlyDictionary<int, IReadOnlyList<int>> s_emptyReplicasAssignments = new ReadOnlyDictionary<int, IReadOnlyList<int>>(new Dictionary<int, IReadOnlyList<int>>());
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TopicConfiguration"/> class.
     /// </summary>
     /// <param name="name">The topic name</param>
     /// <param name="partitions">The number of partitions for the topic</param>
     /// <param name="replicas">Replication factor for the topic</param>
-    public TopicConfiguration(string name, int partitions, short replicas)
+    /// <param name="configs">The configuration to use to create the new topic</param>
+    /// <param name="replicasAssignments">A map from partition id to replica ids</param>
+    public TopicConfiguration(string name, int partitions, short replicas, IDictionary<string, string> configs = null, IDictionary<int, IEnumerable<int>> replicasAssignments = null)
     {
         this.Name = name;
         this.Partitions = partitions;
         this.Replicas = replicas;
+        this.Configs = configs is null ? s_emptyConfigs : new ReadOnlyDictionary<string, string>(configs);
+        this.ReplicasAssignments = replicasAssignments is null
+            ? s_emptyReplicasAssignments
+            : new ReadOnlyDictionary<int, IReadOnlyList<int>>(replicasAssignments.ToDictionary(x => x.Key, x => (IReadOnlyList<int>)x.Value.ToList()));
     }
 
     /// <summary>
@@ -32,4 +45,14 @@ public class TopicConfiguration
     /// Gets the Topic Replication Factor
     /// </summary>
     public short Replicas { get; }
+
+    /// <summary>Gets the configuration to use to create the new topic.</summary>
+    public IReadOnlyDictionary<string, string> Configs { get; }
+
+    /// <summary>
+    ///     Gets the mapping from partition id to replica ids (i.e., static broker ids) or null
+    ///     if the number of partitions and replication factor are specified
+    ///     instead.
+    /// </summary>
+    public IReadOnlyDictionary<int, IReadOnlyList<int>> ReplicasAssignments { get; }
 }


### PR DESCRIPTION
# Description

Dynamic values are valid input when creating a topic.

The PR will allow adding them, so for example, one can provide the retention period and cleanup policy of the topic:
```c#
         clusterManager.CreateIfNotExistsAsync("mytopic", 1, 1, new Dictionary<string, string>
          {
              { "retention.ms", (86400000 * 2).ToString() }, // 2 days
              { "cleanup.policy", "delete" }
          });
```

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
