### PR TITLE
Allow multiple OnStarted and OnStopping callbacks

### DIFF
--- a/src/KafkaFlow/Configuration/ClusterConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ClusterConfigurationBuilder.cs
@@ -98,13 +98,13 @@ internal class ClusterConfigurationBuilder : IClusterConfigurationBuilder
 
     public IClusterConfigurationBuilder OnStopping(Action<IDependencyResolver> handler)
     {
-        _onStoppingHandler = handler;
+        _onStoppingHandler += handler;
         return this;
     }
 
     public IClusterConfigurationBuilder OnStarted(Action<IDependencyResolver> handler)
     {
-        _onStartedHandler = handler;
+        _onStartedHandler += handler;
         return this;
     }
 


### PR DESCRIPTION
# Description

As reported in issue #569 OnStarted and OnStoppind didn't allow for registering multiple callbacks for the same event. By combining the registration of callbacks this fixes the issue.

Fixes #569

## How Has This Been Tested?

Integration Tests added.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
