### PR TITLE
feat: add an ability to call IServiceProvider during configuration

### DIFF
--- a/src/KafkaFlow.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/KafkaFlow.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -25,4 +25,23 @@ public static class ServiceCollectionExtensions
 
         return services.AddSingleton(configurator);
     }
+
+    /// <summary>
+    /// Configures KafkaFlow
+    /// </summary>
+    /// <param name="services">Instance of <see cref="IServiceCollection"/></param>
+    /// <param name="configure">A handler to configure KafkaFlow</param>
+    /// <returns></returns>
+    public static IServiceCollection AddKafka(
+        this IServiceCollection services,
+        Action<IServiceProvider, IKafkaConfigurationBuilder> configure)
+    {
+        return services.AddSingleton(sp =>
+        {
+            var configurator = new KafkaFlowConfigurator(
+                new MicrosoftDependencyConfigurator(services),
+                (builder) => configure(sp, builder));
+            return configurator;
+        });
+    }
 }


### PR DESCRIPTION
# Description

Often the configuration is unknown before the DI container is created, MS Dependency Injection supports factory registration for this. The PR adds an ability to use `IServiceProvider` for library configuration.

Fixes [Kafka configuration from DI · Issue #271 · Farfetch/kafkaflow](https://github.com/Farfetch/kafkaflow/issues/271)  

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation
