### PR TITLE
fix: stop flow manager after calling revoke handlers

### DIFF
--- a/src/KafkaFlow/Consumers/Consumer.cs
+++ b/src/KafkaFlow/Consumers/Consumer.cs
@@ -242,11 +242,11 @@ internal class Consumer : IConsumer
             .SetPartitionsRevokedHandler(
                 (consumer, partitions) =>
                 {
+                    _partitionsRevokedHandlers.ForEach(handler => handler(_dependencyResolver, consumer, partitions));
                     this.Assignment = new List<TopicPartition>();
                     this.Subscription = new List<string>();
                     _currentPartitionsOffsets.Clear();
                     _flowManager.Stop();
-                    _partitionsRevokedHandlers.ForEach(handler => handler(_dependencyResolver, consumer, partitions));
                 })
             .SetErrorHandler((consumer, error) => _errorsHandlers.ForEach(x => x(consumer, error)))
             .SetStatisticsHandler((consumer, statistics) => _statisticsHandlers.ForEach(x => x(consumer, statistics)));


### PR DESCRIPTION
# Description

Call the registered revoke handlers before stopping the ConsumerFlowManager.

Fixes #581

## How Has This Been Tested?

Against the provided [code reproducing the problem](https://github.com/Farfetch/kafkaflow-retry-extensions/issues/151).

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
