### PR TITLE
Fixed possible null exception

### DIFF
--- a/src/KafkaFlow.Admin/Handlers/PauseConsumerByNameHandler.cs
+++ b/src/KafkaFlow.Admin/Handlers/PauseConsumerByNameHandler.cs
@@ -16,11 +16,14 @@ internal class PauseConsumerByNameHandler : IMessageHandler<PauseConsumerByName>
     {
         var consumer = _consumerAccessor[message.ConsumerName];
 
+        if(consumer is null)
+            return Task.CompletedTask;
+
         var assignment = consumer.FilterAssigment(message.Topics);
 
         if (assignment.Any())
         {
-            consumer?.Pause(assignment);
+            consumer.Pause(assignment);
         }
 
         return Task.CompletedTask;


### PR DESCRIPTION
# Description
The code is checking if the consumer is null before to pause it, but doesn't when try to apply the filter.
That could throw a null exception in case ` var consumer = consumerAccessor[message.ConsumerName];` returns null.

This is nothing special, but could be helpful in case you have multiple instances and not all are updated (during a deploy) or when you use the same admin topics from different application.
