### PR TITLE
Fix: Issues with cooperative-sticky strategy

### DIFF
--- a/KafkaFlow.sln
+++ b/KafkaFlow.sln
@@ -96,6 +96,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.OpenTelemetry", "samples\KafkaFlow.Sample.OpenTelemetry\KafkaFlow.Sample.OpenTelemetry.csproj", "{E9E8B374-4165-45F2-8DF5-F141E141AC1D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.Sample.CooperativeSticky", "samples\KafkaFlow.Sample.CooperativeSticky\KafkaFlow.Sample.CooperativeSticky.csproj", "{DBF7B091-11AE-402F-9F36-7E7EB3901B0B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -222,6 +224,10 @@ Global
 		{E9E8B374-4165-45F2-8DF5-F141E141AC1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9E8B374-4165-45F2-8DF5-F141E141AC1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9E8B374-4165-45F2-8DF5-F141E141AC1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBF7B091-11AE-402F-9F36-7E7EB3901B0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DBF7B091-11AE-402F-9F36-7E7EB3901B0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBF7B091-11AE-402F-9F36-7E7EB3901B0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DBF7B091-11AE-402F-9F36-7E7EB3901B0B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -265,6 +271,7 @@ Global
 		{1755E8DB-970C-4A24-8B7C-A2BEC1410BEE} = {7A9B997B-DAAC-4004-94F3-32F6B88E0068}
 		{80080C1D-579E-4AB2-935D-5CFFC51843D8} = {7A9B997B-DAAC-4004-94F3-32F6B88E0068}
 		{E9E8B374-4165-45F2-8DF5-F141E141AC1D} = {303AE78F-6C96-4DF4-AC89-5C4FD53AFF0B}
+		{DBF7B091-11AE-402F-9F36-7E7EB3901B0B} = {303AE78F-6C96-4DF4-AC89-5C4FD53AFF0B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6AE955B5-16B0-41CF-9F12-66D15B3DD1AB}

--- a/samples/KafkaFlow.Sample.CooperativeSticky/HostedService.cs
+++ b/samples/KafkaFlow.Sample.CooperativeSticky/HostedService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using KafkaFlow.Producers;
+using Microsoft.Extensions.Hosting;
+
+namespace KafkaFlow.Sample.CooperativeSticky;
+
+public class HostedService : IHostedService
+{
+    private IMessageProducer _producer;
+    const string producerName = "PrintConsole";
+    const string topicName = "sample-topic";
+
+
+    public HostedService(IProducerAccessor producerAccessor)
+    {
+        _producer = producerAccessor.GetProducer(producerName);
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (true)
+            {
+                await _producer.ProduceAsync(
+                    topicName,
+                    Guid.NewGuid().ToString(),
+                    new TestMessage { Text = $"Message: {Guid.NewGuid()}" });
+                await Task.Delay(500, cancellationToken);
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/samples/KafkaFlow.Sample.CooperativeSticky/KafkaFlow.Sample.CooperativeSticky.csproj
+++ b/samples/KafkaFlow.Sample.CooperativeSticky/KafkaFlow.Sample.CooperativeSticky.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <InvariantGlobalization>true</InvariantGlobalization>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+        <NoWarn>1701;1702;CS1591;SA1600</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <NoWarn>1701;1702;CS1591;SA1600</NoWarn>
+    </PropertyGroup>
+
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\KafkaFlow.LogHandler.Console\KafkaFlow.LogHandler.Console.csproj" />
+        <ProjectReference Include="..\..\src\KafkaFlow.Microsoft.DependencyInjection\KafkaFlow.Microsoft.DependencyInjection.csproj" />
+        <ProjectReference Include="..\..\src\KafkaFlow.Serializer.ProtobufNet\KafkaFlow.Serializer.ProtobufNet.csproj" />
+        <ProjectReference Include="..\..\src\KafkaFlow\KafkaFlow.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    </ItemGroup>
+    
+    
+</Project>

--- a/samples/KafkaFlow.Sample.CooperativeSticky/PrintConsoleHandler.cs
+++ b/samples/KafkaFlow.Sample.CooperativeSticky/PrintConsoleHandler.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace KafkaFlow.Sample.CooperativeSticky;
+
+public class PrintConsoleHandler : IMessageHandler<TestMessage>
+{
+    public Task Handle(IMessageContext context, TestMessage message)
+    {
+        Console.WriteLine(
+            "Partition: {0} | Offset: {1} | Message: {2}",
+            context.ConsumerContext.Partition,
+            context.ConsumerContext.Offset,
+            message.Text);
+
+        return Task.CompletedTask;
+    }
+}

--- a/samples/KafkaFlow.Sample.CooperativeSticky/Program.cs
+++ b/samples/KafkaFlow.Sample.CooperativeSticky/Program.cs
@@ -1,0 +1,53 @@
+﻿using Confluent.Kafka;
+using KafkaFlow;
+using KafkaFlow.Sample.CooperativeSticky;
+using KafkaFlow.Serializer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using AutoOffsetReset = KafkaFlow.AutoOffsetReset;
+
+const string producerName = "PrintConsole";
+const string topicName = "sample-topic";
+var hostBuilder = new HostBuilder();
+hostBuilder.ConfigureServices(services =>
+    services.AddHostedService<HostedService>().AddKafka(
+        kafka => kafka
+            .UseConsoleLog()
+            .AddCluster(
+                cluster => cluster
+                    .WithBrokers(new[] { "localhost:9092" })
+                    .CreateTopicIfNotExists(topicName, 6, 1)
+                    .AddProducer(
+                        producerName,
+                        producer => producer
+                            .DefaultTopic(topicName)
+                            .AddMiddlewares(m => m.AddSerializer<ProtobufNetSerializer>())
+                    )
+                    .AddConsumer(
+                        consumer => consumer
+                            .WithConsumerConfig(new ConsumerConfig
+                            {
+                                PartitionAssignmentStrategy = PartitionAssignmentStrategy.CooperativeSticky,
+                                AutoCommitIntervalMs = 100
+                            })
+                            .Topic(topicName)
+                            .WithGroupId("print-console-handler")
+                            .WithBufferSize(100)
+                            .WithWorkersCount(3)
+                            .WithAutoCommitIntervalMs(10)
+                            .WithAutoOffsetReset(AutoOffsetReset.Latest)
+                            .AddMiddlewares(
+                                middlewares => middlewares
+                                    .AddDeserializer<ProtobufNetDeserializer>()
+                                    .AddTypedHandlers(h => h.AddHandler<PrintConsoleHandler>())
+                            )
+                    )
+            )
+    ));
+
+var build = hostBuilder.Build();
+var kafkaBus = build.Services.CreateKafkaBus();
+await kafkaBus.StartAsync();
+
+await build.RunAsync();
+await kafkaBus.StopAsync();

--- a/samples/KafkaFlow.Sample.CooperativeSticky/README.md
+++ b/samples/KafkaFlow.Sample.CooperativeSticky/README.md
@@ -1,0 +1,28 @@
+# KafkaFlow.Sample
+
+This is a simple sample that shows how to produce and consume messages.
+
+## How to run
+
+### Requirements
+
+-   [.NET 6.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+-   [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+
+### Start the cluster
+
+Using your terminal of choice, start the cluster.
+You can find a docker-compose file at the root of this repository. 
+Position the terminal in that folder and run the following command.
+
+```bash
+docker-compose up -d
+```
+
+### Run the Sample
+
+Using your terminal of choice, start the sample for the sample folder.
+
+```bash
+dotnet run
+```

--- a/samples/KafkaFlow.Sample.CooperativeSticky/TestMessage.cs
+++ b/samples/KafkaFlow.Sample.CooperativeSticky/TestMessage.cs
@@ -1,0 +1,10 @@
+using System.Runtime.Serialization;
+
+namespace KafkaFlow.Sample.CooperativeSticky;
+
+[DataContract]
+public class TestMessage
+{
+    [DataMember(Order = 1)]
+    public string Text { get; set; }
+}

--- a/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using KafkaFlow.Consumers.DistributionStrategies;
+using KafkaFlow.Extensions;
 
 namespace KafkaFlow.Configuration;
 
@@ -251,7 +252,8 @@ internal sealed class ConsumerConfigurationBuilder : IConsumerConfigurationBuild
         consumerConfigCopy.StatisticsIntervalMs = _consumerConfig.StatisticsIntervalMs ?? _statisticsInterval;
 
         consumerConfigCopy.EnableAutoOffsetStore = false;
-        consumerConfigCopy.EnableAutoCommit = false;
+        consumerConfigCopy.EnableAutoCommit = _consumerConfig.PartitionAssignmentStrategy.IsStopTheWorldStrategy() is false;
+        consumerConfigCopy.AutoCommitIntervalMs = _consumerConfig.AutoCommitIntervalMs ?? 5000;
 
         consumerConfigCopy.ReadSecurityInformationFrom(clusterConfiguration);
 

--- a/src/KafkaFlow/Extensions/StrategyExtensions.cs
+++ b/src/KafkaFlow/Extensions/StrategyExtensions.cs
@@ -1,0 +1,17 @@
+using Confluent.Kafka;
+
+namespace KafkaFlow.Extensions;
+
+/// <summary>
+/// Strategy extension methods.
+/// </summary>
+public static class StrategyExtensions
+{
+    /// <summary>
+    /// Determine if the strategy is a "stop the world" behavior.
+    /// </summary>
+    /// <param name="strategy">Strategy</param>
+    /// <returns></returns>
+    public static bool IsStopTheWorldStrategy(this PartitionAssignmentStrategy? strategy) =>
+        strategy is null or PartitionAssignmentStrategy.Range or PartitionAssignmentStrategy.RoundRobin;
+}


### PR DESCRIPTION
# Description

* Added support for consumer strategies that do not require "stop the world" scenarios (e.g., cooperative sticky). This addresses and fixes issues #557 and #456.
* Enabled automatic committing with `confluent.auto.commit: true` for the cooperative sticky consumer strategy, instead of relying solely on manual commits. This change is particularly relevant due to the ongoing issue in librdkafka (see: https://github.com/confluentinc/librdkafka/issues/4059).

## How Has This Been Tested?

Introduced a new sample project specifically designed to evaluate and test the support for the cooperative sticky strategy, allowing for more thorough analysis.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md).
