### PR TITLE
Fix: Produce memory leak (issue #602)

### DIFF
--- a/src/KafkaFlow/Producers/MessageProducer.cs
+++ b/src/KafkaFlow/Producers/MessageProducer.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Text;
-using System.Threading.Tasks;
 using Confluent.Kafka;
 using KafkaFlow.Authentication;
 using KafkaFlow.Configuration;
+using System;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace KafkaFlow.Producers;
 
@@ -334,20 +334,31 @@ internal class MessageProducer : IMessageProducer, IDisposable
         var localProducer = this.EnsureProducer();
         var message = CreateMessage(context);
 
-        if (partition.HasValue)
+        try
         {
+            if (partition.HasValue)
+            {
+                localProducer.Produce(
+                    new TopicPartition(context.ProducerContext.Topic, partition.Value),
+                    message,
+                    Handler);
+
+                return;
+            }
+
             localProducer.Produce(
-                new TopicPartition(context.ProducerContext.Topic, partition.Value),
+                context.ProducerContext.Topic,
                 message,
                 Handler);
-
-            return;
         }
-
-        localProducer.Produce(
-            context.ProducerContext.Topic,
-            message,
-            Handler);
+        catch (Exception ex)
+        {
+            DeliveryReport<byte[], byte[]> report = new()
+            {
+                Error = new Error(ErrorCode.Local_Fatal, ex.Message, isFatal: true),
+            };
+            Handler(report);
+        }
 
         void Handler(DeliveryReport<byte[], byte[]> report)
         {


### PR DESCRIPTION
# Description

Catches exceptions thrown by Confluent's Produce method. This change allows the sync produce method to complete its TaskCompletionSource.

Fixes #602

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
