### PR TITLE
feat: Exit infinite loop when Exception is thrown.

### DIFF
--- a/src/KafkaFlow/Consumers/Consumer.cs
+++ b/src/KafkaFlow/Consumers/Consumer.cs
@@ -192,6 +192,7 @@ internal class Consumer : IConsumer
             catch (Exception ex)
             {
                 _logHandler.Error("Kafka Consumer Error", ex, null);
+                throw;
             }
             finally
             {


### PR DESCRIPTION
# Description

When exception is thrown in ConsumerAsync method, code never exits and is stuck in an infinite loop flooding log with exception messages.

## How Has This Been Tested?

Tested locally

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
