### PR TITLE
feat: abstract confluent builders into factories

### DIFF
--- a/src/KafkaFlow.SchemaRegistry/ClusterConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow.SchemaRegistry/ClusterConfigurationBuilderExtensions.cs
@@ -21,7 +21,11 @@ public static class ClusterConfigurationBuilderExtensions
     {
         var config = new SchemaRegistryConfig();
         handler(config);
-        cluster.DependencyConfigurator.AddSingleton<ISchemaRegistryClient>(_ => new CachedSchemaRegistryClient(config));
+
+        cluster.DependencyConfigurator
+            .AddSingleton<ISchemaRegistryClientFactory, SchemaRegistryClientFactory>()
+            .AddSingleton(resolver => resolver.Resolve<ISchemaRegistryClientFactory>().CreateSchemaRegistryClient(config));
+
         return cluster;
     }
 }

--- a/src/KafkaFlow.SchemaRegistry/ISchemaRegistryClientFactory.cs
+++ b/src/KafkaFlow.SchemaRegistry/ISchemaRegistryClientFactory.cs
@@ -1,0 +1,16 @@
+﻿using Confluent.SchemaRegistry;
+
+namespace KafkaFlow;
+
+/// <summary>
+/// Factory for creating an <see cref="ISchemaRegistryClient"/>.
+/// </summary>
+public interface ISchemaRegistryClientFactory
+{
+    /// <summary>
+    /// Creates an instance of <see cref="ISchemaRegistryClient"/>.
+    /// </summary>
+    /// <param name="config">The schema registry config</param>
+    /// <returns>An <see cref="ISchemaRegistryClient"/>.</returns>
+    ISchemaRegistryClient CreateSchemaRegistryClient(SchemaRegistryConfig config);
+}

--- a/src/KafkaFlow.SchemaRegistry/SchemaRegistryClientFactory.cs
+++ b/src/KafkaFlow.SchemaRegistry/SchemaRegistryClientFactory.cs
@@ -1,0 +1,11 @@
+﻿using Confluent.SchemaRegistry;
+
+namespace KafkaFlow;
+
+internal class SchemaRegistryClientFactory : ISchemaRegistryClientFactory
+{
+    public ISchemaRegistryClient CreateSchemaRegistryClient(SchemaRegistryConfig config)
+    {
+        return new CachedSchemaRegistryClient(config);
+    }
+}

--- a/src/KafkaFlow/Clusters/AdminClientBuilderFactory.cs
+++ b/src/KafkaFlow/Clusters/AdminClientBuilderFactory.cs
@@ -1,0 +1,11 @@
+﻿using Confluent.Kafka;
+
+namespace KafkaFlow.Clusters;
+
+internal class AdminClientBuilderFactory : IAdminClientBuilderFactory
+{
+    public IAdminClientBuilder CreateAdminClientBuilder(AdminClientConfig config)
+    {
+        return new AdminClientBuilderWrapper(config);
+    }
+}

--- a/src/KafkaFlow/Clusters/AdminClientBuilderWrapper.cs
+++ b/src/KafkaFlow/Clusters/AdminClientBuilderWrapper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Confluent.Kafka;
+
+namespace KafkaFlow.Clusters;
+
+internal class AdminClientBuilderWrapper : IAdminClientBuilder
+{
+    private readonly AdminClientBuilder _builder;
+
+    public AdminClientBuilderWrapper(AdminClientConfig config)
+    {
+        _builder = new AdminClientBuilder(config);
+    }
+
+    public IAdminClientBuilder SetOAuthBearerTokenRefreshHandler(Action<IProducer<Null, Null>, string> oAuthBearerTokenRefreshHandler)
+    {
+        this._builder.SetOAuthBearerTokenRefreshHandler(oAuthBearerTokenRefreshHandler);
+
+        return this;
+    }
+
+    public IAdminClient Build()
+    {
+        return this._builder.Build();
+    }
+}

--- a/src/KafkaFlow/Clusters/ClusterManager.cs
+++ b/src/KafkaFlow/Clusters/ClusterManager.cs
@@ -18,7 +18,7 @@ internal class ClusterManager : IClusterManager, IDisposable
 
     private readonly ConcurrentDictionary<string, TopicMetadata> _topicMetadataCache = new();
 
-    public ClusterManager(ILogHandler logHandler, ClusterConfiguration configuration)
+    public ClusterManager(IAdminClientBuilderFactory clientBuilderFactory, ILogHandler logHandler, ClusterConfiguration configuration)
     {
         _logHandler = logHandler;
         _configuration = configuration;
@@ -33,7 +33,7 @@ internal class ClusterManager : IClusterManager, IDisposable
 
                 config.ReadSecurityInformationFrom(configuration);
 
-                var adminClientBuilder = new AdminClientBuilder(config);
+                var adminClientBuilder = clientBuilderFactory.CreateAdminClientBuilder(config);
 
                 var security = configuration.GetSecurityInformation();
 

--- a/src/KafkaFlow/Clusters/IAdminClientBuilder.cs
+++ b/src/KafkaFlow/Clusters/IAdminClientBuilder.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Confluent.Kafka;
+
+namespace KafkaFlow.Clusters;
+
+/// <inheritdoc cref="AdminClientBuilder"/>
+public interface IAdminClientBuilder
+{
+    /// <inheritdoc cref="AdminClientBuilder.SetOAuthBearerTokenRefreshHandler"/>
+    IAdminClientBuilder SetOAuthBearerTokenRefreshHandler(
+        Action<IProducer<Null, Null>, string> oAuthBearerTokenRefreshHandler);
+
+    /// <inheritdoc cref="AdminClientBuilder.Build"/>
+    IAdminClient Build();
+}

--- a/src/KafkaFlow/Clusters/IAdminClientBuilderFactory.cs
+++ b/src/KafkaFlow/Clusters/IAdminClientBuilderFactory.cs
@@ -1,0 +1,16 @@
+﻿using Confluent.Kafka;
+
+namespace KafkaFlow.Clusters;
+
+/// <summary>
+/// Factory for creating an <see cref="AdminClientBuilder"/>.
+/// </summary>
+public interface IAdminClientBuilderFactory
+{
+    /// <summary>
+    /// Creates an instance of <see cref="AdminClientBuilder"/>.
+    /// </summary>
+    /// <param name="config">The admin client config</param>
+    /// <returns>An <see cref="AdminClientBuilder"/>.</returns>
+    IAdminClientBuilder CreateAdminClientBuilder(AdminClientConfig config);
+}

--- a/src/KafkaFlow/Configuration/KafkaConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/KafkaConfigurationBuilder.cs
@@ -38,12 +38,15 @@ internal class KafkaConfigurationBuilder : IKafkaConfigurationBuilder
         {
             _dependencyConfigurator.AddSingleton<IClusterManager>(
                 resolver =>
-                    new ClusterManager(resolver.Resolve<ILogHandler>(), cluster));
+                    new ClusterManager(resolver.Resolve<IAdminClientBuilderFactory>(), resolver.Resolve<ILogHandler>(), cluster));
         }
 
         _dependencyConfigurator
             .AddTransient(typeof(ILogHandler), _logHandlerType)
             .AddSingleton<IDateTimeProvider, DateTimeProvider>()
+            .AddSingleton<IAdminClientBuilderFactory, AdminClientBuilderFactory>()
+            .AddSingleton<IProducerBuilderFactory, ProducerBuilderFactory>()
+            .AddSingleton<IConsumerBuilderFactory, ConsumerBuilderFactory>()
             .AddSingleton<IConsumerAccessor>(new ConsumerAccessor())
             .AddSingleton<IConsumerManagerFactory>(new ConsumerManagerFactory())
             .AddSingleton<IClusterManagerAccessor, ClusterManagerAccessor>()

--- a/src/KafkaFlow/Consumers/ConsumerBuilderFactory.cs
+++ b/src/KafkaFlow/Consumers/ConsumerBuilderFactory.cs
@@ -1,0 +1,11 @@
+﻿using Confluent.Kafka;
+
+namespace KafkaFlow.Consumers;
+
+internal class ConsumerBuilderFactory : IConsumerBuilderFactory
+{
+    public IConsumerBuilder CreateConsumerBuilder(ConsumerConfig config)
+    {
+        return new ConsumerBuilderWrapper(config);
+    }
+}

--- a/src/KafkaFlow/Consumers/ConsumerBuilderWrapper.cs
+++ b/src/KafkaFlow/Consumers/ConsumerBuilderWrapper.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using Confluent.Kafka;
+
+namespace KafkaFlow.Consumers;
+
+internal class ConsumerBuilderWrapper : IConsumerBuilder
+{
+    private readonly ConsumerBuilder<byte[], byte[]> _builder;
+
+    public ConsumerBuilderWrapper(ConsumerConfig config)
+    {
+        _builder = new ConsumerBuilder<byte[], byte[]>(config);
+    }
+
+    public IConsumerBuilder SetPartitionsAssignedHandler(Action<IConsumer<byte[], byte[]>, List<TopicPartition>> partitionAssignmentHandler)
+    {
+        this._builder.SetPartitionsAssignedHandler(partitionAssignmentHandler);
+
+        return this;
+    }
+
+    public IConsumerBuilder SetPartitionsRevokedHandler(Action<IConsumer<byte[], byte[]>, List<Confluent.Kafka.TopicPartitionOffset>> partitionsRevokedHandler)
+    {
+        this._builder.SetPartitionsRevokedHandler(partitionsRevokedHandler);
+
+        return this;
+    }
+
+    public IConsumerBuilder SetErrorHandler(Action<IConsumer<byte[], byte[]>, Error> errorHandler)
+    {
+        this._builder.SetErrorHandler(errorHandler);
+
+        return this;
+    }
+
+    public IConsumerBuilder SetStatisticsHandler(Action<IConsumer<byte[], byte[]>, string> statisticsHandler)
+    {
+        this._builder.SetStatisticsHandler(statisticsHandler);
+
+        return this;
+    }
+
+    public IConsumerBuilder SetOAuthBearerTokenRefreshHandler(Action<IConsumer<byte[], byte[]>, string> oAuthBearerTokenRefreshHandler)
+    {
+        this._builder.SetOAuthBearerTokenRefreshHandler(oAuthBearerTokenRefreshHandler);
+
+        return this;
+    }
+
+    public IConsumer<byte[], byte[]> Build()
+    {
+        return this._builder.Build();
+    }
+}

--- a/src/KafkaFlow/Consumers/IConsumerBuilder.cs
+++ b/src/KafkaFlow/Consumers/IConsumerBuilder.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using Confluent.Kafka;
+
+namespace KafkaFlow.Consumers;
+
+/// <inheritdoc cref="ConsumerBuilder{TKey,TValue}"/>
+public interface IConsumerBuilder
+{
+    /// <inheritdoc cref="ConsumerBuilder{TKey,TValue}.SetPartitionsAssignedHandler(Action{IConsumer{TKey,TValue},List{TopicPartition}})"/>
+    IConsumerBuilder SetPartitionsAssignedHandler(
+        Action<IConsumer<byte[], byte[]>, List<TopicPartition>> partitionAssignmentHandler);
+
+    /// <inheritdoc cref="ConsumerBuilder{TKey,TValue}.SetPartitionsRevokedHandler(Action{IConsumer{TKey,TValue},List{Confluent.Kafka.TopicPartitionOffset}})"/>
+    IConsumerBuilder SetPartitionsRevokedHandler(
+        Action<IConsumer<byte[], byte[]>, List<Confluent.Kafka.TopicPartitionOffset>> partitionsRevokedHandler);
+
+    /// <inheritdoc cref="ConsumerBuilder{TKey,TValue}.SetErrorHandler"/>
+    IConsumerBuilder SetErrorHandler(
+        Action<IConsumer<byte[], byte[]>, Error> errorHandler);
+
+    /// <inheritdoc cref="ConsumerBuilder{TKey,TValue}.SetStatisticsHandler"/>
+    IConsumerBuilder SetStatisticsHandler(
+        Action<IConsumer<byte[], byte[]>, string> statisticsHandler);
+
+    /// <inheritdoc cref="ConsumerBuilder{TKey,TValue}.SetOAuthBearerTokenRefreshHandler"/>
+    IConsumerBuilder SetOAuthBearerTokenRefreshHandler(
+        Action<IConsumer<byte[], byte[]>, string> oAuthBearerTokenRefreshHandler);
+
+    /// <inheritdoc cref="ConsumerBuilder{TKey,TValue}.Build"/>
+    IConsumer<byte[], byte[]> Build();
+}

--- a/src/KafkaFlow/Consumers/IConsumerBuilderFactory.cs
+++ b/src/KafkaFlow/Consumers/IConsumerBuilderFactory.cs
@@ -1,0 +1,16 @@
+﻿using Confluent.Kafka;
+
+namespace KafkaFlow.Consumers;
+
+/// <summary>
+/// Factory for creating an <see cref="ConsumerBuilder{TKey,TValue}"/>.
+/// </summary>
+public interface IConsumerBuilderFactory
+{
+    /// <summary>
+    /// Creates an instance of <see cref="ConsumerBuilder{TKey,TValue}"/>.
+    /// </summary>
+    /// <param name="config">The consumer config</param>
+    /// <returns>An <see cref="ConsumerBuilder{TKey,TValue}"/>.</returns>
+    IConsumerBuilder CreateConsumerBuilder(ConsumerConfig config);
+}

--- a/src/KafkaFlow/Producers/IProducerBuilder.cs
+++ b/src/KafkaFlow/Producers/IProducerBuilder.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Confluent.Kafka;
+
+namespace KafkaFlow.Producers;
+
+/// <inheritdoc cref="ProducerBuilder{TKey,TValue}"/>
+public interface IProducerBuilder
+{
+    /// <inheritdoc cref="ProducerBuilder{TKey,TValue}.SetErrorHandler"/>
+    IProducerBuilder SetErrorHandler(
+        Action<IProducer<byte[], byte[]>, Error> errorHandler);
+
+    /// <inheritdoc cref="ProducerBuilder{TKey,TValue}.SetStatisticsHandler"/>
+    IProducerBuilder SetStatisticsHandler(
+        Action<IProducer<byte[], byte[]>, string> statisticsHandler);
+
+    /// <inheritdoc cref="ProducerBuilder{TKey,TValue}.SetOAuthBearerTokenRefreshHandler"/>
+    IProducerBuilder SetOAuthBearerTokenRefreshHandler(
+        Action<IProducer<byte[], byte[]>, string> oAuthBearerTokenRefreshHandler);
+
+    /// <inheritdoc cref="ProducerBuilder{TKey,TValue}.Build"/>
+    IProducer<byte[], byte[]> Build();
+}

--- a/src/KafkaFlow/Producers/IProducerBuilderFactory.cs
+++ b/src/KafkaFlow/Producers/IProducerBuilderFactory.cs
@@ -1,0 +1,16 @@
+﻿using Confluent.Kafka;
+
+namespace KafkaFlow.Producers;
+
+/// <summary>
+/// Factory for creating an <see cref="ProducerBuilder{TKey,TValue}"/>.
+/// </summary>
+public interface IProducerBuilderFactory
+{
+    /// <summary>
+    /// Creates an instance of <see cref="ProducerBuilder{TKey,TValue}"/>.
+    /// </summary>
+    /// <param name="config">The producer config</param>
+    /// <returns>An <see cref="ProducerBuilder{TKey,TValue}"/>.</returns>
+    IProducerBuilder CreateProducerBuilder(ProducerConfig config);
+}

--- a/src/KafkaFlow/Producers/ProducerBuilderFactory.cs
+++ b/src/KafkaFlow/Producers/ProducerBuilderFactory.cs
@@ -1,0 +1,11 @@
+﻿using Confluent.Kafka;
+
+namespace KafkaFlow.Producers;
+
+internal class ProducerBuilderFactory : IProducerBuilderFactory
+{
+    public IProducerBuilder CreateProducerBuilder(ProducerConfig config)
+    {
+        return new ProducerBuilderWrapper(config);
+    }
+}

--- a/src/KafkaFlow/Producers/ProducerBuilderWrapper.cs
+++ b/src/KafkaFlow/Producers/ProducerBuilderWrapper.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Confluent.Kafka;
+
+namespace KafkaFlow.Producers;
+
+internal class ProducerBuilderWrapper : IProducerBuilder
+{
+    private readonly ProducerBuilder<byte[], byte[]> _builder;
+
+    public ProducerBuilderWrapper(ProducerConfig config)
+    {
+        _builder = new ProducerBuilder<byte[], byte[]>(config);
+    }
+
+    public IProducerBuilder SetErrorHandler(Action<IProducer<byte[], byte[]>, Error> errorHandler)
+    {
+        this._builder.SetErrorHandler(errorHandler);
+
+        return this;
+    }
+
+    public IProducerBuilder SetStatisticsHandler(Action<IProducer<byte[], byte[]>, string> statisticsHandler)
+    {
+        this._builder.SetStatisticsHandler(statisticsHandler);
+
+        return this;
+    }
+
+    public IProducerBuilder SetOAuthBearerTokenRefreshHandler(Action<IProducer<byte[], byte[]>, string> oAuthBearerTokenRefreshHandler)
+    {
+        this._builder.SetOAuthBearerTokenRefreshHandler(oAuthBearerTokenRefreshHandler);
+
+        return this;
+    }
+
+    public IProducer<byte[], byte[]> Build()
+    {
+        return this._builder.Build();
+    }
+}


### PR DESCRIPTION
# Description

Fixes #623 

Moves the Confluent producer/consumer builder logic into abstractions that can provide an integration point for an in-memory broker, for use in unit and integration testing. 

Currently we need to run a real Kafka server (or docker container) to run our testing suite, but it would be nicer (and faster) if we could control the broker configuration in such a way to move messages around in memory without needing a live Kafka server. 

A follow up change to this could be an in-memory broker Nuget package that can be used for testing purposes.

The use case for this would be something like this:

```c#
var services = new ServiceCollection()
    .AddKafka(...);

services.AddSingleton<IProducerBuilderFactory, InMemoryProducerBuilderFactory>(); // Replaces the default factory

public class InMemoryProducerBuilderFactory : IProducerBuilderFactory
{
    public IProducerBuilder CreateProducerBuilder(ProducerConfig config)
    {
        return new InMemoryProducerBuilder();
    }
}

public class InMemoryProducerBuilder : IProducerBuilder
{
    public IProducer<byte[], byte[]> Build()
    {
        return new InMemoryProducer();
    }
}
```

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
