### PR TITLE
fix: replace `messaging.type` with `messaging.system` in generic tags

### DIFF
--- a/src/KafkaFlow.OpenTelemetry/ActivitySourceAccessor.cs
+++ b/src/KafkaFlow.OpenTelemetry/ActivitySourceAccessor.cs
@@ -18,7 +18,7 @@ internal static class ActivitySourceAccessor
     {
         // https://opentelemetry.io/docs/languages/net/libraries/#note-on-versioning
         // https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.9.0/src/Shared/SemanticConventions.cs
-        activity?.SetTag("message.type", MessagingSystemId);
+        activity?.SetTag("messaging.system", MessagingSystemId);
         activity?.SetTag("peer.service", string.Join(",", bootstrapServers ?? Enumerable.Empty<string>()));
     }
 }


### PR DESCRIPTION
# Description

The current code in main branch wrongly replaced `messaging.system` with `messaging.type`. This PR reverts that change

https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
