### PR TITLE
fix: add emptiness check for linger.ms and statistics.interval.ms

### DIFF
--- a/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
@@ -13,7 +13,7 @@ internal class ProducerConfigurationBuilder : IProducerConfigurationBuilder
     private string _topic;
     private ProducerConfig _producerConfig;
     private Acks? _acks;
-    private int _statisticsInterval;
+    private int? _statisticsInterval;
     private double? _lingerMs;
     private ProducerCustomFactory _customFactory = (producer, _) => producer;
 
@@ -86,8 +86,15 @@ internal class ProducerConfigurationBuilder : IProducerConfigurationBuilder
     {
         _producerConfig ??= new ProducerConfig();
 
-        _producerConfig.StatisticsIntervalMs = _statisticsInterval;
-        _producerConfig.LingerMs = _lingerMs;
+        if (_statisticsInterval.HasValue)
+        {
+            _producerConfig.StatisticsIntervalMs = _statisticsInterval;
+        }
+
+        if (_lingerMs.HasValue)
+        {
+            _producerConfig.LingerMs = _lingerMs;
+        }
 
         _producerConfig.ReadSecurityInformationFrom(clusterConfiguration);
 

--- a/tests/KafkaFlow.UnitTests/ConfigurationBuilders/ProducerConfigurationBuilderTests.cs
+++ b/tests/KafkaFlow.UnitTests/ConfigurationBuilders/ProducerConfigurationBuilderTests.cs
@@ -119,4 +119,78 @@ public class ProducerConfigurationBuilderTests
         configuration.BaseProducerConfig.CompressionType.Should().Be(compressionType);
         configuration.BaseProducerConfig.CompressionLevel.Should().Be(-1);
     }
+
+    [TestMethod]
+    public void Build_UseProducerConfig_ShouldNotOverrideLingerMsAndStatisticsIntervalMs()
+    {
+        // Arrange
+        var clusterConfiguration = _fixture.Create<ClusterConfiguration>();
+
+        const double lingerMs = 1000;
+        const int statisticsMs = 2000;
+        var producerConfig = new ProducerConfig
+        {
+            LingerMs = lingerMs,
+            StatisticsIntervalMs = statisticsMs
+        };
+
+        _target.WithProducerConfig(producerConfig);
+
+        // Act
+        var configuration = _target.Build(clusterConfiguration);
+
+        // Assert
+        configuration.Cluster.Should().Be(clusterConfiguration);
+        configuration.BaseProducerConfig.LingerMs.Should().Be(lingerMs);
+        configuration.BaseProducerConfig.StatisticsIntervalMs.Should().Be(statisticsMs);
+    }
+
+    [TestMethod]
+    public void Build_UseProducerConfigAndUseLingerMs_ShouldOverrideLingerMs()
+    {
+        // Arrange
+        var clusterConfiguration = _fixture.Create<ClusterConfiguration>();
+
+        const double producerConfigLingerMs = 1000;
+        const double expectedLingerMs = 2000;
+        var producerConfig = new ProducerConfig { LingerMs = producerConfigLingerMs };
+
+        _target
+            .WithProducerConfig(producerConfig)
+            .WithLingerMs(expectedLingerMs);
+
+        // Act
+        var configuration = _target.Build(clusterConfiguration);
+
+        // Assert
+        configuration.Cluster.Should().Be(clusterConfiguration);
+        configuration.BaseProducerConfig.LingerMs.Should().Be(expectedLingerMs);
+    }
+
+    [TestMethod]
+    public void Build_UseProducerConfigAndUseStatisticsIntervalMs_ShouldOverrideStatisticsIntervalMs()
+    {
+        // Arrange
+        var clusterConfiguration = _fixture.Create<ClusterConfiguration>();
+
+        const int producerConfigStatisticsIntervalMs = 1000;
+        const int expectedStatisticsIntervalMs = 2000;
+        var producerConfig = new ProducerConfig
+        {
+            StatisticsIntervalMs = producerConfigStatisticsIntervalMs
+        };
+
+        _target
+            .WithProducerConfig(producerConfig)
+            .WithStatisticsIntervalMs(expectedStatisticsIntervalMs);
+
+        // Act
+        var configuration = _target.Build(clusterConfiguration);
+
+        // Assert
+        configuration.Cluster.Should().Be(clusterConfiguration);
+        configuration
+            .BaseProducerConfig.StatisticsIntervalMs.Should()
+            .Be(expectedStatisticsIntervalMs);
+    }
 }


### PR DESCRIPTION
# Description

Added a null check for `_lingerMs` and `_statisticsInterval` before overriding `_producerConfig.LingerMs` and `_producerConfig.StatisticsIntervalMs` to avoid overwriting original values with empty ones.

Fixes #711 

## How Has This Been Tested?

NuGet package was built and tested in an application where `linger.ms` and `statistics.interval.ms` were provided in `ProducerConfig`

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
