### PR TITLE
feat: update to otel semconv 1.40.0

### DIFF
--- a/src/KafkaFlow.OpenTelemetry/ActivitySourceAccessor.cs
+++ b/src/KafkaFlow.OpenTelemetry/ActivitySourceAccessor.cs
@@ -1,24 +1,26 @@
-﻿using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.Text;
 
 namespace KafkaFlow.OpenTelemetry;
 
 internal static class ActivitySourceAccessor
 {
-    internal const string ActivityString = "otel_activity";
+    internal const string ActivityContextItemKey = "otel_activity";
     internal const string MessagingSystemId = "kafka";
-    internal const string AttributeMessagingOperation = "messaging.operation";
-    internal const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
-    internal const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
 
     internal static readonly ActivitySource s_activitySource = new(KafkaFlowInstrumentation.ActivitySourceName, KafkaFlowInstrumentation.Version);
 
-    internal static void SetGenericTags(Activity activity, IEnumerable<string> bootstrapServers)
+    internal static void SetGenericTags(Activity activity)
     {
         // https://opentelemetry.io/docs/languages/net/libraries/#note-on-versioning
         // https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.9.0/src/Shared/SemanticConventions.cs
         activity?.SetTag("messaging.system", MessagingSystemId);
-        activity?.SetTag("peer.service", string.Join(",", bootstrapServers ?? Enumerable.Empty<string>()));
     }
+
+    internal static string FormatMessageKey(object key) => key switch
+    {
+        null => null,
+        byte[] bytes => Encoding.UTF8.GetString(bytes),
+        _ => key.ToString(),
+    };
 }

--- a/src/KafkaFlow.OpenTelemetry/AttributeKeys.cs
+++ b/src/KafkaFlow.OpenTelemetry/AttributeKeys.cs
@@ -1,0 +1,16 @@
+namespace KafkaFlow.OpenTelemetry;
+
+internal static class AttributeKeys
+{
+    public const string ClientId = "messaging.client.id";
+    public const string ConsumerGroupName = "messaging.consumer.group.name";
+    public const string DestinationName = "messaging.destination.name";
+    public const string DestinationPartitionId = "messaging.destination.partition.id";
+    public const string ErrorType = "error.type";
+    public const string KafkaMessageKey = "messaging.kafka.message.key";
+    public const string KafkaMessageTombstone = "messaging.kafka.message.tombstone";
+    public const string KafkaOffset = "messaging.kafka.offset";
+    public const string MessageBodySize = "messaging.message.body.size";
+    public const string OperationName = "messaging.operation.name";
+    public const string OperationType = "messaging.operation.type";
+}

--- a/src/KafkaFlow.OpenTelemetry/OpenTelemetryConsumerEventsHandler.cs
+++ b/src/KafkaFlow.OpenTelemetry/OpenTelemetryConsumerEventsHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
@@ -12,9 +12,6 @@ namespace KafkaFlow.OpenTelemetry;
 internal static class OpenTelemetryConsumerEventsHandler
 {
     private const string ProcessString = "process";
-    private const string AttributeMessagingSourceName = "messaging.source.name";
-    private const string AttributeMessagingKafkaConsumerGroup = "messaging.kafka.consumer.group";
-    private const string AttributeMessagingKafkaSourcePartition = "messaging.kafka.source.partition";
     private static readonly TextMapPropagator s_propagator = Propagators.DefaultTextMapPropagator;
 
     public static Task OnConsumeStarted(IMessageContext context, KafkaFlowInstrumentationOptions options)
@@ -37,11 +34,11 @@ internal static class OpenTelemetryConsumerEventsHandler
                 activity?.AddBaggage(item.Key, item.Value);
             }
 
-            context?.Items.Add(ActivitySourceAccessor.ActivityString, activity);
+            context?.Items.Add(ActivitySourceAccessor.ActivityContextItemKey, activity);
 
-            ActivitySourceAccessor.SetGenericTags(activity, context?.Brokers);
+            ActivitySourceAccessor.SetGenericTags(activity);
 
-            if (activity != null && activity.IsAllDataRequested)
+            if (activity is { IsAllDataRequested: true })
             {
                 SetConsumerTags(context, activity);
             }
@@ -58,9 +55,9 @@ internal static class OpenTelemetryConsumerEventsHandler
 
     public static Task OnConsumeCompleted(IMessageContext context)
     {
-        if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
+        if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityContextItemKey, out var value) && value is Activity activity)
         {
-            activity?.Dispose();
+            activity.Dispose();
         }
 
         return Task.CompletedTask;
@@ -68,12 +65,12 @@ internal static class OpenTelemetryConsumerEventsHandler
 
     public static Task OnConsumeError(IMessageContext context, Exception ex)
     {
-        if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
+        if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityContextItemKey, out var value) && value is Activity activity)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            activity?.RecordException(ex);
-
-            activity?.Dispose();
+            activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity.SetTag(AttributeKeys.ErrorType, ex.GetType().FullName);
+            activity.AddException(ex);
+            activity.Dispose();
         }
 
         return Task.CompletedTask;
@@ -86,13 +83,29 @@ internal static class OpenTelemetryConsumerEventsHandler
 
     private static void SetConsumerTags(IMessageContext context, Activity activity)
     {
-        string messageKey = context.Message.Key != null ? Encoding.UTF8.GetString(context.Message.Key as byte[]) : string.Empty;
+        activity.SetTag(AttributeKeys.OperationType, ProcessString);
+        activity.SetTag(AttributeKeys.OperationName, ProcessString);
+        activity.SetTag(AttributeKeys.DestinationName, context.ConsumerContext.Topic);
+        activity.SetTag(AttributeKeys.DestinationPartitionId, context.ConsumerContext.Partition.ToString());
+        activity.SetTag(AttributeKeys.ConsumerGroupName, context.ConsumerContext.GroupId);
+        activity.SetTag(AttributeKeys.ClientId, context.ConsumerContext.ConsumerName);
+        activity.SetTag(AttributeKeys.KafkaOffset, context.ConsumerContext.Offset);
 
-        activity.SetTag(ActivitySourceAccessor.AttributeMessagingOperation, ProcessString);
-        activity.SetTag(AttributeMessagingSourceName, context.ConsumerContext.Topic);
-        activity.SetTag(AttributeMessagingKafkaConsumerGroup, context.ConsumerContext.GroupId);
-        activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageKey, messageKey);
-        activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageOffset, context.ConsumerContext.Offset);
-        activity.SetTag(AttributeMessagingKafkaSourcePartition, context.ConsumerContext.Partition);
+        var messageKey = ActivitySourceAccessor.FormatMessageKey(context.Message.Key);
+
+        if (messageKey != null)
+        {
+            activity.SetTag(AttributeKeys.KafkaMessageKey, messageKey);
+        }
+
+        if (context.Message.Value == null)
+        {
+            activity.SetTag(AttributeKeys.KafkaMessageTombstone, true);
+        }
+
+        if (context.Message.Value is byte[] body)
+        {
+            activity.SetTag(AttributeKeys.MessageBodySize, body.Length);
+        }
     }
 }

--- a/src/KafkaFlow.OpenTelemetry/OpenTelemetryProducerEventsHandler.cs
+++ b/src/KafkaFlow.OpenTelemetry/OpenTelemetryProducerEventsHandler.cs
@@ -11,16 +11,15 @@ namespace KafkaFlow.OpenTelemetry;
 
 internal static class OpenTelemetryProducerEventsHandler
 {
+    private const string SendString = "send";
     private const string PublishString = "publish";
-    private const string AttributeMessagingDestinationName = "messaging.destination.name";
-    private const string AttributeMessagingKafkaDestinationPartition = "messaging.kafka.destination.partition";
     private static readonly TextMapPropagator s_propagator = Propagators.DefaultTextMapPropagator;
 
     public static Task OnProducerStarted(IMessageContext context, KafkaFlowInstrumentationOptions options)
     {
         try
         {
-            var activityName = !string.IsNullOrEmpty(context?.ProducerContext.Topic) ? $"{context?.ProducerContext.Topic} {PublishString}" : PublishString;
+            var activityName = !string.IsNullOrEmpty(context?.ProducerContext.Topic) ? $"{context.ProducerContext.Topic} {PublishString}" : PublishString;
 
             // Start an activity with a name following the semantic convention of the OpenTelemetry messaging specification.
             // The convention also defines a set of attributes (in .NET they are mapped as `tags`) to be populated in the activity.
@@ -35,7 +34,7 @@ internal static class OpenTelemetryProducerEventsHandler
 
             if (activity != null)
             {
-                context?.Items.Add(ActivitySourceAccessor.ActivityString, activity);
+                context?.Items.Add(ActivitySourceAccessor.ActivityContextItemKey, activity);
 
                 contextToInject = activity.Context;
 
@@ -53,9 +52,9 @@ internal static class OpenTelemetryProducerEventsHandler
             // Inject the ActivityContext into the message headers to propagate trace context to the receiving service.
             s_propagator.Inject(new PropagationContext(contextToInject, Baggage.Current), context, InjectTraceContextIntoBasicProperties);
 
-            ActivitySourceAccessor.SetGenericTags(activity, context?.Brokers);
+            ActivitySourceAccessor.SetGenericTags(activity);
 
-            if (activity != null && activity.IsAllDataRequested)
+            if (activity is { IsAllDataRequested: true })
             {
                 SetProducerTags(context, activity);
             }
@@ -72,9 +71,9 @@ internal static class OpenTelemetryProducerEventsHandler
 
     public static Task OnProducerCompleted(IMessageContext context)
     {
-        if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
+        if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityContextItemKey, out var value) && value is Activity activity)
         {
-            activity?.Dispose();
+            activity.Dispose();
         }
 
         return Task.CompletedTask;
@@ -82,12 +81,12 @@ internal static class OpenTelemetryProducerEventsHandler
 
     public static Task OnProducerError(IMessageContext context, Exception ex)
     {
-        if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityString, out var value) && value is Activity activity)
+        if (context.Items.TryGetValue(ActivitySourceAccessor.ActivityContextItemKey, out var value) && value is Activity activity)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            activity?.RecordException(ex);
-
-            activity?.Dispose();
+            activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity.SetTag(AttributeKeys.ErrorType, ex.GetType().FullName);
+            activity.AddException(ex);
+            activity.Dispose();
         }
 
         return Task.CompletedTask;
@@ -95,7 +94,7 @@ internal static class OpenTelemetryProducerEventsHandler
 
     private static void InjectTraceContextIntoBasicProperties(IMessageContext context, string key, string value)
     {
-        if (!context.Headers.Any(x => x.Key == key))
+        if (context.Headers.All(x => x.Key != key))
         {
             context.Headers.SetString(key, value, Encoding.ASCII);
         }
@@ -103,10 +102,30 @@ internal static class OpenTelemetryProducerEventsHandler
 
     private static void SetProducerTags(IMessageContext context, Activity activity)
     {
-        activity.SetTag(ActivitySourceAccessor.AttributeMessagingOperation, PublishString);
-        activity.SetTag(AttributeMessagingDestinationName, context?.ProducerContext.Topic);
-        activity.SetTag(AttributeMessagingKafkaDestinationPartition, context?.ProducerContext.Partition);
-        activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageKey, context?.Message.Key);
-        activity.SetTag(ActivitySourceAccessor.AttributeMessagingKafkaMessageOffset, context?.ProducerContext.Offset);
+        activity.SetTag(AttributeKeys.OperationType, SendString);
+        activity.SetTag(AttributeKeys.OperationName, PublishString);
+        activity.SetTag(AttributeKeys.DestinationName, context?.ProducerContext.Topic);
+
+        if (context?.ProducerContext.Partition.HasValue == true)
+        {
+            activity.SetTag(AttributeKeys.DestinationPartitionId, context.ProducerContext.Partition.Value.ToString());
+        }
+
+        if (context?.ProducerContext.Offset.HasValue == true)
+        {
+            activity.SetTag(AttributeKeys.KafkaOffset, context.ProducerContext.Offset);
+        }
+
+        var messageKey = ActivitySourceAccessor.FormatMessageKey(context?.Message.Key);
+
+        if (messageKey != null)
+        {
+            activity.SetTag(AttributeKeys.KafkaMessageKey, messageKey);
+        }
+
+        if (context?.Message.Value == null)
+        {
+            activity.SetTag(AttributeKeys.KafkaMessageTombstone, true);
+        }
     }
 }


### PR DESCRIPTION
# Description

Updates `KafkaFlow.OpenTelemetry` to the OTEL Semantic Conventions `1.40.0` (current version at time of writing).

https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/messaging/kafka.md

This contains some breaking changes to attribute names due to the unstable nature of the spec.

Implements #470

## Summary of changes

  ### Removed

  | Attribute | Reason |
  |---|---|
  | `peer.service` | Contained the bootstrap server list, which does not represent the broker that handled a given message |

  ### Renamed

  | Old | New | Where |
  |---|---|---|
  | `messaging.operation` = `"publish"` | `messaging.operation.type` = `"send"` + `messaging.operation.name` = `"publish"` | Producer |
  | `messaging.source.name` | `messaging.destination.name` | Consumer |
  | `messaging.kafka.consumer.group` | `messaging.consumer.group.name` | Consumer |
  | `messaging.kafka.message.offset` | `messaging.kafka.offset` | Both |
  | `messaging.kafka.source.partition` | `messaging.destination.partition.id` | Consumer |
  | `messaging.kafka.destination.partition` | `messaging.destination.partition.id` | Producer |

  ### Added

  | Attribute | Where | Notes |
  |---|---|---|
  | `messaging.client.id` | Consumer | Set to `ConsumerContext.ConsumerName` — closest available proxy for the Kafka client ID, which is not exposed by `IConsumerContext` |
  | `messaging.kafka.message.tombstone` = `true` | Both | Only emitted when message value is null |
  | `messaging.message.body.size` | Consumer | Only emitted when the message value is still `byte[]` (i.e. before deserialization middleware has run) |
  | `error.type` | Both | Emitted in error handlers only; value is the exception's fully-qualified type name |

  ### Bug fix

  `messaging.kafka.message.key`: the consumer previously always emitted this tag (empty string for null keys, with an unsafe cast to `byte[]`), and the producer emitted the raw
  `object`. Both now share a `FormatMessageKey` helper that UTF-8 decodes `byte[]` keys, calls `ToString()` on other types, and omits the tag entirely when the key is null.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
